### PR TITLE
Add size option & make explainer not focus on implementation-specific stuff

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -290,7 +290,8 @@ pairs:
     means this element and its descendants will be ignored in cases like
     find-in-page, anchor link navigation, focus navigation, etc.
 * (optional): `size`:  `[width, height]`
-   * Indicates the *locked content size* of the locked element. See [sizing](#sizing) section for more detail.
+   * |width| and |height| should be non-negative numbers.
+   * Indicates the *locked content size* of the locked element, in pixels. See [sizing](#sizing) section for more detail.
    * If not specified, the *locked content size* will default to `[0, 0]`.
 
 ### DisplayLockContext.locked

--- a/explainer.md
+++ b/explainer.md
@@ -36,6 +36,8 @@ However, this **causes problems for the web app** because a lot of user-agent fe
 accessibility, indexability, focus navigation, anchor links, etc.
 **depend on having the contents in the DOM**.
 
+### Proposal: Display Locking
+
 We propose a new concept, **display locking**, to assist developers with **alleviating
 jank caused by DOM updates** and having some control on **when to pay rendering costs**,
 while also **allowing things that depend on the updates to get the up-to-date values** when urgent.
@@ -60,16 +62,19 @@ the page to jank** and **only pay rendering costs on things that really need it*
 In the rest of the document, we describe the display locking concept in detail.
 We will first examine some motivating examples which we commonly observe in rich
 web applications. We will discuss the intent of each of the examples, as well as
-the areas that can potentially cause jank. In order to understand the display
-locking proposal details, we will then describe common phases in user-agent
-lifecycles. Specifically, we will talk about script, layout, paint, compositing,
-and presentation to the screen as well as areas that display locking is geared
-to improve. We will then move on to describe the API changes required to
+the areas that can potentially cause jank.
+We will then move on to describe the API changes required to
 implement display locking, with a description of each new functionality. With
 that in place, we will revisit the motivating examples to see how display
 locking can be applied in order to improve their performance. Finally, we will
-discuss possible display locking implementations, along with possible corner
-cases and limitations.
+discuss possible corner cases and limitations.
+
+In order to understand the display locking proposal details, a brief explanation
+of common phases in user-agent lifecycles is available [here](./lifecycle.md).
+Specifically, it talks about script, layout, paint, compositing,
+and presentation to the screen as well as areas that display locking is geared
+to improve. 
+A brief explanation of possible display locking implementations is also [available](./implementation.md).
 
 ---
 ### Motivating Examples
@@ -166,95 +171,14 @@ In the rest of this document, we discuss display locking and how it can help
 with situations like the ones mentioned above.
 
 ---
-### Background: User-agent's Update Phases
-
-When processing DOM changes, the user-agent typically goes through several
-stages, which we will call *update phases*. In order to understand how display
-locking proposal is going to work, we will briefly discuss the major update
-phases.
-
-**Note to the reader**: these phases are covered in greater detail in the
-[rendering event
-loop](https://github.com/chrishtr/rendering/blob/master/rendering-event-loop.md).
-Here, we briefly go over the main update phases that happen in a typical
-user-agent.
-
-#### Script
-During the script update phase, the user-agent executes script requested by the
-page. At this time, the script on the page is free to mutate the DOM in any way.
-It can do things like update element style, position elements based on a custom
-animation, add and remove elements, and many other things. Synchronous
-javascript functions that are invoked here will finish to completion. This means
-that if a function runs for a long time, other update phases cannot proceed and
-the page janks. Script, however, cannot be interrupted by the user-agent.
-Because of this, developers should always be mindful of long running script.
-
-After the script phase finishes, the DOM structure and style for the next visual
-update is finalized.
-
-#### Layout and paint
-During the layout and paint phase, the user-agent goes through the DOM and
-updates any properties that need to be updated. Specifically, it can apply new
-style to elements, position and size the elements based on style, as well as
-generate draw commands needed to visually display the content to the screen.
-Note that it is wasteful to do these steps on every element, so the user-agent
-typically maintains a set of elements that have changed, or could have been
-changed by updates to style or elements which may have happened during script
-execution. This is typically done using some sort of dirty bits, or a list of
-dirty elements.
-
-For the elements that do need updates, the user-agent processes them in some
-defined order. This work finishes to completion. This means that depending on
-the complexity of the DOM, and the number of changes required, this process can
-take a long time. This, again, causes jank since other update phases do not
-happen while layout and paint is executing.
-
-The output of the layout and paint phase is a sequence of draw commands which,
-when executed, will draw the current visual update.
-
-#### Compositing
-In order to avoid doing repeated work, modern user-agents also employ
-compositing. Compositing is a process of splitting up draw commands into
-separate layers, each with its own backing, in order to avoid re-rasterizing
-content in other layers.
-
-As an example, if a div is animating and moving across the screen using a css
-animation, then it might make sense to separate the div and its draw commands
-into a separate layer. This would mean that the content of the div can be
-rasterized once, and the animation would simply move the backing across the
-screen. This is typically significantly faster than invalidating content,
-discarding the previously rasterized content, and rasterizing new content in a
-new location.
-
-Compositing is typically determined by the user-agent based on heuristics. It
-isn’t perfect, but it can help by reducing the amount of time spent rasterizing
-content. On top of that, the developer can provide hints to the user-agent
-indicating that an element, and its subtree, are likely to move together. For
-example, “will-change: transform” is one such property that the user-agent may
-use to promote the affected element to a separate layer.
-
-The output of the compositing update phase is a set of layers with either draw
-commands, or rasterized textures.
-
-#### Presentation
-The final update phase is presentation to the screen. By this time, the
-user-agent has generated draw commands, or possibly even rasterized those into
-separate layers, and arranged the layers in the final locations. With GPU
-acceleration, this update phase issues GPU commands to the driver to display the
-layers and its contents.
-
-At the end of the presentation phase, the content is finally visible to the
-user.
-
----
-### Proposal
+### Proposed API
 
 The display locking proposal is intended to **improve the script, layout, paint,
 as well as parts of the compositing update phases**. In particular, it aims to add
 javascript APIs to allow the developer to lock an element for display.
 
 With the proposed APIs,
-**web authors can control when not to pay the updating costs for a locked element**,
+**web authors can control when not to pay the rendering costs for a locked subtree**,
 and also **request the user-agent to do the updates in a non-janky way**.
 
 ### Example code
@@ -276,33 +200,35 @@ remainingItems.forEach(item => {
     let itemEl = createElementForItem(item);
     itemEl.displayLock.acquire({ timeout: Infinity, activatable: true });
     itemsList.appendChild(itemEl);
-    // We can do expensive operations to the items without worrying about the rendering costs.
+    // We can do expensive operations to the item's subtree without worrying about the rendering costs.
     // After we finished all the operations we can trigger a co-operative update & commit.
     // We might do this in a fancier way by not actually committing the element,
     // leaving it locked and detecting when to commit by using IntersectionObservers etc,
     // but that's out of the scope of this example :)
-    doExpensiveOperationsToEl(itemEl).then(element.updateAndCommit);
+    doExpensiveOperationsToChildren(itemEl).then(element.updateAndCommit);
+    itemEl.appendChild(...);
+    itemEl.firstChild.style = "...";
   });
 });
 
 // Getting style/layout values within a locked subtree :
-// - If we access child.offsetTop directly, it will cause a forced synchronous update
+// - If we call getComputedStyle directly, it will cause a forced synchronous style update
 //   (see [what-forces-layout](https://gist.github.com/paulirish/5d52fb081b3570c81e3a)).
 // - We can call update() on the locked element to trigger a co-operative update and get
 //   the value after the calculations finished instead.
-function getOffsetTopForLockedElementChild(child, lockedElement) {
+function getComputedStyleForLockedElementChild(child, lockedElement) {
   return new Promise((resolve) => {
-    lockedElement.displayLock.update().then(() => { resolve(child.offsetTop) };
+    lockedElement.displayLock.update().then(() => { resolve(getComputedStyle(child)) };
   });
 }
 </script>
 ```
 
-### Proposed APIs Details
+### API Details
 
 #### Element.displayLock
 
-With display locking, each of the `Element` objects has a new attribute,
+With display locking, the `Element` interface has a new attribute,
 `displayLock` which returns a `DisplayLockContext` representing the display
 lock. The rest of the display locking functionality happens by interacting with this
 object. The `DisplayLockContext` is bound to the element from which it was
@@ -312,25 +238,22 @@ retrieved, meaning that operations on the object will affect that element.
 
 Acquire performs the following steps:
 
-* It finishes all of the update phases for the current state, if needed.
-* (in lock-after-append) It saves the output of the layout and paint phase (the
-  painted draw commands) and stashes them to be used when the locked element
-  needs to be painted. Note that in the case of an element that is outside of
-  the DOM, this painted output is empty.
-* It marks the source element as locked for display, preventing normal update
-  phases to recurse into it.
-* It returns a promise which, when resolved, indicates that the above work has
-  been completed.
+* Mark the source element as locked for display, preventing normal update
+  phases to recurse into its flat-tree descendants.
+* Finish all of the rendering update phases for the locked element, if needed.
+* Clear the painted output for all of the locked element's flat-tree descendants.
 
-Note that the acquire call takes options, consisting of the following key-value
+It returns a promise which, when resolved, indicates that the above work has been completed.
+
+Note that the acquire method may take options, consisting of the following key-value
 pairs:
 * (optional) `timeout`: `timeoutInMilliseconds`
   * This is an optional timeout value for the duration of the lock. When the
     lock is acquired, and commit is not called within `timeoutInMilliseconds`
     milliseconds, the lock will be automatically committed. This is a safety
     valve for protecting pages from inadvertently leaving an element locked
-    indefinitely due to uncaught exceptions or other bugs in the code. For a
-    more sophisticated use cases, the value of Infinity will effectively disable
+    indefinitely due to uncaught exceptions or other bugs in the code. For
+    more sophisticated use cases, the value of `Infinity` will effectively disable
     the timeout.
 * (optional) `activatable`: `true|false`
   * Signifies whether the user-agent can automatically commit the lock
@@ -339,6 +262,9 @@ pairs:
   * Not setting this, or setting this to `false`,
     means this element and its descendants will be ignored in cases like
     find-in-page, anchor link navigation, focus navigation, etc.
+* (optional): `size`:  `[width , height]`
+   * Indicates the *locked content size* of the locked element. See [sizing](#sizing) section for more detail.
+   * If not specified, the locked element will not take any space, similar to `display: none` elements.
 
 #### DisplayLockContext.locked
 
@@ -348,33 +274,31 @@ and `false` if not.
 
 #### The locked state
 
-##### What happens
+##### The locked element
 
-When its lock is acquired, if the element already existed in the DOM,
-the visual content of the nodes in the subtree of the element that was present at the time the lock was acquired is cleared,
-but the locked element itself will still be rendered and laid out normally.
+When its lock is acquired, the locked element itself will still be rendered and laid out normally.
+Changes to the DOM, style, layout, etc of the *locked element itself* will be applied as it would on any other normal element.
 
-If the element was locked before being inserted into the DOM,
-when it got inserted to the DOM, it will be in an state similar to `display: none;`.
-See [lock-after-append](#lock-after-append-locked-subtree) vs [lock-before-append](#lock-before-append-locked-element--subtree).
+##### Sizing
 
-##### Modifications to the locked subtree
+When locked, the locked element is treated similar to as if it has [size containment](https://www.w3.org/TR/css-contain-1/#containment-size) with some differences.
 
-Changes to the DOM, style, layout, etc of the *locked element itself*
-will be applied immediately if the element is locked after it is inserted to the DOM,
-but will be ignored if it is locked before it is inserted to the DOM.
-See [lock-after-append](#lock-after-append-locked-subtree) vs [lock-before-append](#lock-before-append-locked-element--subtree).
+* If some style rule specifies the size of the locked element, we will use that size for the locked element.
+* If there are no style rule specifying the size of the locked element, we will use the size given in the `acquire` call's options.
+Instead of being treated as having no contents, the locked element will behave as if there is one child with the given *locked content size* as its intrinsic width and height, for sizing purposes.
+* If there are no size specified in the `acquire` call, the locked element will not take any space, similar to `display: none` elements instead.
 
-Changes to the *descendants of a locked element* updates the DOM in such a way that script can inspect it immediately,
-but no updates wil be painted until the element is unlocked,
+##### The locked subtree
+
+When its lock is acquired, the **visual content of the nodes of flat-tree descendants of the element is cleared**, similar to `display: none`.
+
+Changes to the *flat-tree descendants of a locked element* updates the DOM in such a way that script can inspect it immediately,
+but no rendering updates wil be painted until the element is unlocked,
 through `commit()` or the user-agent activating the element.
 
-Style and layout updates will not be inspectable immediately without first trigerring an update,
-either through calling `update()`
-or trigerring a *forced update* by calling style and layout inducing methods/properties
-(see [what-forces-layout](https://gist.github.com/paulirish/5d52fb081b3570c81e3a)),
-which will force style or layout synchronously in order to return correct values,
-but not actually painting it.
+Style and layout updates can happen without unlocking the element,
+through calling `update()` or triggering a *forced update* by calling style and layout inducing methods/properties
+(see [what-forces-layout](https://gist.github.com/paulirish/5d52fb081b3570c81e3a)).
 
 #### DisplayLockContext.update()
 
@@ -484,7 +408,7 @@ even if we activate `#fourth`,
 it will not be visible because `#second` is still locked.
 
 ---
-### Restrictions
+### Requirement: Style and Layout Containment
 
 In consideration of display locking, we have also discussed when it would and
 would not be appropriate to allow an element to be locked. One main
@@ -502,143 +426,6 @@ This allows us to better reason about the expected behavior of the page. Specifi
   of the locked element. Similarly to layout containment, this ensures that we
   can process any number of elements on the locked subtree without visually
   changing the content on the rest of the page.
-
----
-### Implementation description
-
-Note to the reader: this section describes the sample prototype implementation.
-The design choices here are not meant to represent final design decisions, but
-act as a proof of concept implementation in Blink. Feel free to skip this
-section.
-
-There are three key components to implementing the display locking API.
-
-First, in lock-after-append, we need to be able to snapshot the current visual
-representation of the locked element, so that future updates to the page have
-content to populate in place of the locked element. Since the user-agents vary
-greatly in the way they generate commands for drawing content to screen, we will
-omit a detailed discussion of this. It suffices to say that any kind of
-double-buffering approach would work. That is, the user-agent could generate the
-commands needed to render the element and its subtree at the time the lock is
-acquired. Then, for the duration of the lock it uses these commands to render
-the content, while accumulating new draw commands in a separate buffer to be
-used when the lock is released.
-
-Second, we need to implement the co-operative update phases.  That is, we need a
-way to prevent the update phases in the locked subtree from blocking other
-phases from occurring for other parts of the tree. The co-operative updates part
-of the API can be implemented in several ways. Here, we describe one possible
-implementation, which is the basis for our prototype implementation. We call
-this approach budgeted update phases.
-
-##### Budgeted update phases
-
-In the budgeted update phases approach, we introduce a new concept to the
-user-agent, called an update budget. This budget dictates how much of a locked
-subtree should be processed. As an example, consider the following the following
-pseudo code for laying out an element:
-
-```cpp
-void LayoutElement::UpdateLayout() {
-  UpdateOwnLayout();
-  ClearDirtyBitForSelfLayout();
-
-  for (auto* child : GetChildren()) {
-    if (child->NeedsLayoutForSelfOrChildren())
-      child->UpdateLayout();
-  }
-  ClearDirtyBitForChildrenLayout();
-}
-```
-
-Here the code goes through the layout tree walk. At each step, the element
-updates its own layout, then iterates over all of its children. If a child, or a
-sub-element of the child needs a layout, then it recursively descends into the
-call. Also note that every time an element completes its layout, it clears the
-dirty bit for itself and after processing its children, it also clears the dirty
-bit that indicates its children need processing.
-
-With budgeted update phases, the recursive call gets a context which tracks the
-current budget. Furthermore, it checks the current budget to see if it expired.
-If so, it aborts doing any future work. When it comes to dirty bits, if the
-element processed its own layout, it clears its dirty bit. Also, if all of the
-children and, by extension, their subtrees successfully complete layout, it also
-clears the children dirty bit.
-
-```cpp
-void LayoutElement::UpdateLayout(DisplayLockContext& context) {
-  auto scoped_visitor = context.VisitObject(this);
-  if (context.BudgetExpired()) {
-    context.DidSkipObject();
-    return;
-  }
-  UpdateOwnLayout();
-  ClearDirtyBitForSelfLayout();
-  context.DidProcessObject();
-
-  for (auto* child : GetChildren()) {
-    if (child->NeedsLayoutForSelfOrChildren())
-      child->UpdateLayout(context);
-  }
-  if (!context.HadSkippedDescendants())
-    ClearDirtyBitForChildrenLayout();
-}
-```
-
-Here, the budget is generated if context is visited with a locked element. That
-is, if `this` specified in `VisitObject` is locked, then the context generates a
-budget which will be used for all subtree calculations. In cases that the
-context is not working in a locked subtree, `BudgetExpired()` always returns
-false, meaning that work can proceed.
-
-By adding similar code to all update phases, we achieve co-operative processing
-of locked subtrees. Note that if a budget expired on during one of the phases,
-such as layout, then we won’t process the subtree at all for the future phases,
-such as paint. The reason for this is that the budget that we generate is stored
-on a display lock which is associated with an element. Hence, if we have an
-expired budget at an earlier phase, then it is guaranteed to be expired at a
-later phase. As the code processes the DOM tree, it essentially aborts doing
-work on a locked subtree if an earlier phase has not finished its work on that
-subtree. All other parts of the subtree, like the rAF spinner in our earlier
-example, are still processed as normal.
-
-For completeness, the budget can consist of several things:
-
-* Time budget: this tracks the time that has elapsed since work started and
-  expires after a predefined period.
-* Element count budget: this tracks the number of elements that have been
-  processed, and expires after a fixed number was completed.
-* A combination of the two: this tracks the number of elements that have been
-  processed, and after a fixed number is complete, it checks if the time has
-  expired. If it did, the budget expires. Otherwise, it continues to process the
-  next batch of elements.
-
-##### Other approaches
-
-Budgeted update phases is only one of the ways to achieve co-operative work.
-Other approaches are possible and may yield different behavior depending on
-implementation:
-
-* Threaded update phase: locked subtrees can be processed on a separate thread.
-* Fixed phase updates: locked subtrees could be processed one update phase at a
-  time. For example, layout finishes first and skips the other phases. On the
-  next frame, paint finishes, and skips the remainder. Etc.
-
-It’s possible that other approaches could have better behavior than budgeted
-update phases, but any approach is feasible as long as it implements
-non-janking phase updates.
-
-Another consideration is what to display when the element is locked for display.
-As described in the implementation details, one possibility is to snapshot the
-current visual representation and use that throughout the lock's lifetime. Other
-possbilities are listed below:
-* Do not show any content until the processing is done.
-* Allow the developer to specify the content to display
-  * Allow the developer to specify HTML to display instead of the content while
-    the real content is being processed
-  * Allow the developer to specify a Bitmap to display when the element is
-    locked, possibly but not necessarily containing the result of the content at
-    the time the lock was acquired.
 
 ---
 ### Examples revisited
@@ -718,84 +505,7 @@ presented without jank.
 &nbsp;
 
 ---
-### Locked subtree vs locked element + subtree
-
-Display locking supports two modes of operation, distinguished by when the lock
-is acquired
-
-#### Lock-after-append. (locked subtree)
-
-When the element's lock is acquired while the element is already a part of the
-DOM, visual content of elements within the locked subtree
-(not the locked element itself) is cleared
-and changes to the subtree will not be reflected on screen until the lock is committed
-and the corresponding promise resolves.
-
-Note that in this mode, the locked element is rendered normally and changes to the
-element itself (e.g. border, size) are updated synchronously. In other words,
-the element itself is not locked for display, only its subtree.
-
-This mode is appropriate to use when the element's subtree needs to be updated
-without jank.
-
-#### Lock-before-append (locked element + subtree)
-
-When the element's lock is acquired before the element is inserted into the DOM,
-then the element itself as well as its subtree are considered locked. This means
-that when the element is inserted into the DOM it will not visually change the
-output of the page.
-
-In this mode, changes to either the element itself or to the subtree will not be
-reflected on screen until the lock is committed and the corresponding promise
-resolves.
-
-This mode is appropriate to use when a new element or a widget is inserted into
-the page and it should present asynchonously when ready without causing jank.
-
----
-### Dealing with user input
-
-One of the difficult aspects of locking an element for display in
-lock-after-append mode is deciding what to do with user input (e.g. mouse
-clicks) that are targeted at the element which is locked for display.
-
-##### Queuing up input and replaying
-
-One option is to queue up the user input replaying it once the element is
-unlocked.
-
-Immediately, there is a problem with this approach: conceptually, user
-input is targeted at what the user is currently seeing on screen. However, when
-the display is locked for view, it means that whatever is currently visible does
-not necessarily reflect the DOM that currently comprises the element. To put it
-differently, script could have already mutated the DOM, removed interactive
-elements, added more interactive elements, etc, which means that the user input
-may be targeting an unexpected (from the user's perspective) element.
-
-Based on this argument, it seems that replaying the user input would often cause
-unexpected interactions. The only case where it might be reasonable to replay
-user input is if the locked subtree was not and _will_ not be modified before it
-is unlocked. However, detecting whether script intends to modify the locked
-subtree's DOM is impossible.
-
-##### Ignoring input
-
-Another alternative, which seems more prudent, is to ignore the user input when
-the target is a locked subtree. This prevents unexpected interactions.
-
-However, this comes at a cost of potential user frustration when attempting to
-interact with a locked subtree. From the user's perspective, the page would
-appear to be frozen: buttons don't change state, text fields don't gain focus,
-etc. An option to mitigate the appearance of a frozen page is to display an
-affordance, such as graying out the locked element, or displaying a spinner, if
-the user attempts to interact with it.
-
-This option does not seem to be ideal, since it's hard to agree on what type of
-affordance makes sense to display in any particular instance. That being said,
-it appears to be a better choice when compared to simply ignoring user input.
-
----
-### Other edge cases
+### Edge cases
 
 There are a number of edge cases that need to be considered when working with
 display locking. This section briefly lists a few of them, but the list is far
@@ -836,12 +546,6 @@ from complete.
       what is required to get the queried information. Another possibility is to
       simply disallow such queries into the locked subtree, failing with an
       invalid number returned.
-* Find-in-page and tab order.
-    * It is unclear whether the content put into a locked subtree should be
-      discoverable by find-in-page or tab order navigation. It is possible that
-      this decision will be left up to the script author by adding an additional
-      option to `acquire()`, which would dictate whether the content modified is
-      searchable (e.g. { searchable: true }).
 
 Display locking will certainly have edge cases that need to be considered, some
 of which we have listed here. The general feeling is that the edge cases are

--- a/implementation.md
+++ b/implementation.md
@@ -2,7 +2,7 @@
 
 Note to the reader: this describes the sample prototype implementation.
 The design choices here are not meant to represent final design decisions, but
-act as a proof of concept implementation in Blink
+act as a proof of concept implementation in Blink.
 
 To implement the co-operative update phases, we need a
 way to prevent the update phases in the locked subtree from blocking other

--- a/implementation.md
+++ b/implementation.md
@@ -1,0 +1,109 @@
+# Implementation description
+
+Note to the reader: this describes the sample prototype implementation.
+The design choices here are not meant to represent final design decisions, but
+act as a proof of concept implementation in Blink
+
+To implement the co-operative update phases, we need a
+way to prevent the update phases in the locked subtree from blocking other
+phases from occurring for other parts of the tree. The co-operative updates part
+of the API can be implemented in several ways. Here, we describe one possible
+implementation, which is the basis for our prototype implementation. We call
+this approach budgeted update phases.
+
+##### Budgeted update phases
+
+In the budgeted update phases approach, we introduce a new concept to the
+user-agent, called an update budget. This budget dictates how much of a locked
+subtree should be processed. As an example, consider the following the following
+pseudo code for laying out an element:
+
+```cpp
+void LayoutElement::UpdateLayout() {
+  UpdateOwnLayout();
+  ClearDirtyBitForSelfLayout();
+
+  for (auto* child : GetChildren()) {
+    if (child->NeedsLayoutForSelfOrChildren())
+      child->UpdateLayout();
+  }
+  ClearDirtyBitForChildrenLayout();
+}
+```
+
+Here the code goes through the layout tree walk. At each step, the element
+updates its own layout, then iterates over all of its children. If a child, or a
+sub-element of the child needs a layout, then it recursively descends into the
+call. Also note that every time an element completes its layout, it clears the
+dirty bit for itself and after processing its children, it also clears the dirty
+bit that indicates its children need processing.
+
+With budgeted update phases, the recursive call gets a context which tracks the
+current budget. Furthermore, it checks the current budget to see if it expired.
+If so, it aborts doing any future work. When it comes to dirty bits, if the
+element processed its own layout, it clears its dirty bit. Also, if all of the
+children and, by extension, their subtrees successfully complete layout, it also
+clears the children dirty bit.
+
+```cpp
+void LayoutElement::UpdateLayout(DisplayLockContext& context) {
+  auto scoped_visitor = context.VisitObject(this);
+  if (context.BudgetExpired()) {
+    context.DidSkipObject();
+    return;
+  }
+  UpdateOwnLayout();
+  ClearDirtyBitForSelfLayout();
+  context.DidProcessObject();
+
+  for (auto* child : GetChildren()) {
+    if (child->NeedsLayoutForSelfOrChildren())
+      child->UpdateLayout(context);
+  }
+  if (!context.HadSkippedDescendants())
+    ClearDirtyBitForChildrenLayout();
+}
+```
+
+Here, the budget is generated if context is visited with a locked element. That
+is, if `this` specified in `VisitObject` is locked, then the context generates a
+budget which will be used for all subtree calculations. In cases that the
+context is not working in a locked subtree, `BudgetExpired()` always returns
+false, meaning that work can proceed.
+
+By adding similar code to all update phases, we achieve co-operative processing
+of locked subtrees. Note that if a budget expired on during one of the phases,
+such as layout, then we won’t process the subtree at all for the future phases,
+such as paint. The reason for this is that the budget that we generate is stored
+on a display lock which is associated with an element. Hence, if we have an
+expired budget at an earlier phase, then it is guaranteed to be expired at a
+later phase. As the code processes the DOM tree, it essentially aborts doing
+work on a locked subtree if an earlier phase has not finished its work on that
+subtree. All other parts of the subtree, like the rAF spinner in the explainer's
+example, are still processed as normal.
+
+For completeness, the budget can consist of several things:
+
+* Time budget: this tracks the time that has elapsed since work started and
+  expires after a predefined period.
+* Element count budget: this tracks the number of elements that have been
+  processed, and expires after a fixed number was completed.
+* A combination of the two: this tracks the number of elements that have been
+  processed, and after a fixed number is complete, it checks if the time has
+  expired. If it did, the budget expires. Otherwise, it continues to process the
+  next batch of elements.
+
+##### Other approaches
+
+Budgeted update phases is only one of the ways to achieve co-operative work.
+Other approaches are possible and may yield different behavior depending on
+implementation:
+
+* Threaded update phase: locked subtrees can be processed on a separate thread.
+* Fixed phase updates: locked subtrees could be processed one update phase at a
+  time. For example, layout finishes first and skips the other phases. On the
+  next frame, paint finishes, and skips the remainder. Etc.
+
+It’s possible that other approaches could have better behavior than budgeted
+update phases, but any approach is feasible as long as it implements
+non-janking phase updates.

--- a/lifecycle.md
+++ b/lifecycle.md
@@ -1,0 +1,79 @@
+# Background: User-agent's Update Phases
+
+When processing DOM changes, the user-agent typically goes through several
+stages, which we will call *update phases*. In order to understand how display
+locking proposal is going to work, we will briefly discuss the major update
+phases.
+
+**Note to the reader**: these phases are covered in greater detail in the
+[rendering event
+loop](https://github.com/chrishtr/rendering/blob/master/rendering-event-loop.md).
+Here, we briefly go over the main update phases that happen in a typical
+user-agent.
+
+## Script
+During the script update phase, the user-agent executes script requested by the
+page. At this time, the script on the page is free to mutate the DOM in any way.
+It can do things like update element style, position elements based on a custom
+animation, add and remove elements, and many other things. Synchronous
+javascript functions that are invoked here will finish to completion. This means
+that if a function runs for a long time, other update phases cannot proceed and
+the page janks. Script, however, cannot be interrupted by the user-agent.
+Because of this, developers should always be mindful of long running script.
+
+After the script phase finishes, the DOM structure and style for the next visual
+update is finalized.
+
+## Layout and paint
+During the layout and paint phase, the user-agent goes through the DOM and
+updates any properties that need to be updated. Specifically, it can apply new
+style to elements, position and size the elements based on style, as well as
+generate draw commands needed to visually display the content to the screen.
+Note that it is wasteful to do these steps on every element, so the user-agent
+typically maintains a set of elements that have changed, or could have been
+changed by updates to style or elements which may have happened during script
+execution. This is typically done using some sort of dirty bits, or a list of
+dirty elements.
+
+For the elements that do need updates, the user-agent processes them in some
+defined order. This work finishes to completion. This means that depending on
+the complexity of the DOM, and the number of changes required, this process can
+take a long time. This, again, causes jank since other update phases do not
+happen while layout and paint is executing.
+
+The output of the layout and paint phase is a sequence of draw commands which,
+when executed, will draw the current visual update.
+
+## Compositing
+In order to avoid doing repeated work, modern user-agents also employ
+compositing. Compositing is a process of splitting up draw commands into
+separate layers, each with its own backing, in order to avoid re-rasterizing
+content in other layers.
+
+As an example, if a div is animating and moving across the screen using a css
+animation, then it might make sense to separate the div and its draw commands
+into a separate layer. This would mean that the content of the div can be
+rasterized once, and the animation would simply move the backing across the
+screen. This is typically significantly faster than invalidating content,
+discarding the previously rasterized content, and rasterizing new content in a
+new location.
+
+Compositing is typically determined by the user-agent based on heuristics. It
+isn’t perfect, but it can help by reducing the amount of time spent rasterizing
+content. On top of that, the developer can provide hints to the user-agent
+indicating that an element, and its subtree, are likely to move together. For
+example, “will-change: transform” is one such property that the user-agent may
+use to promote the affected element to a separate layer.
+
+The output of the compositing update phase is a set of layers with either draw
+commands, or rasterized textures.
+
+## Presentation
+The final update phase is presentation to the screen. By this time, the
+user-agent has generated draw commands, or possibly even rasterized those into
+separate layers, and arranged the layers in the final locations. With GPU
+acceleration, this update phase issues GPU commands to the driver to display the
+layers and its contents.
+
+At the end of the presentation phase, the content is finally visible to the
+user.


### PR DESCRIPTION
* Adds size option & brief explanation
* Moves impl specific stuff, lifecycle explanation to different files
* Simplifies example
* Remove remaining references to stale pixels stuff
* Minor tidying

Maybe add these here, or maybe future PR:
* Possible difference in layout values while locked, maybe even specifically mention getBoundingClientRect, offsetTop etc?
* Mention possible bad performance with flex etc