### PR TITLE
Specify 'inclusive' ancestors in element activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The div's subtree does not render to the screen, but when updateRendering is cal
 
 ## Element activation by the user agent
 
-When an element is not rendered because it's a part of a not-rendered subtree caused by `rendersubtree`, there are some actions in the page that might require the element (and its ancestors) to be rendered to work properly. If all of the element's ancestors' `rendersubtree` attributes contain `activatable` (or not set), then the user agent can *activate* the element. This will change all of the non-null `rendersubtree` value of all of its ancestors to the empty string - causing the element and its ancestors to get rendered.
+When an element is not rendered because it's a part of a not-rendered subtree caused by `rendersubtree`, there are some actions in the page that might require the element (and its ancestors) to be rendered to work properly. If all of the element's ancestors' `rendersubtree` attributes contain `activatable` (or not set), then the user agent can *activate* the element. This will change all of the non-null `rendersubtree` value of all of its inclusive ancestors to the empty string - causing the element and its ancestors to get rendered.
 
 ```html
 <div id="focusable" rendersubtree="invisible activatable" tabindex=0>Focus me!</div>


### PR DESCRIPTION
As discussed in #90, clarify that activation applies to its inclusive ancestors.