### PR TITLE
Clarifiy focus and selection parts of 'auto' and 'hidden'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -139,7 +139,7 @@ Inherited: no
 
     : <dfn export>auto</dfn>
     :: The element [=gains containment=]. 
-         If *all of* the following conditions hold then the element is also [=skipped=]:
+         If <strong>all of</strong> the following conditions hold then the element is also [=skipped=]:
            * The element is [=off-screen=].
            * Neither the element nor any of its [=subtree=] elements are
                focused as described in the <a
@@ -153,14 +153,18 @@ Inherited: no
          It is important to note that the contents of the [=subtree=] must be
          accessible to user-agent features such as find-in-page, tab order
          navigation, etc. This is true regardless of whether the element is
-         [=skipped=] or not.
+         [=skipped=] or not. In particular, this means that elements in the
+         [=subtree=] of a [=skipped=] ''subtree-visibility: auto'' element are
+         able to be focused and selected.
 
     : <dfn export>hidden</dfn>
     :: The element is [=skipped=].
 
          Note that in this case, the contents of the [=subtree=] are not accessible
          to user-agent features, such as find-in-page, tab order navigation,
-         etc.
+         etc. This means that elements in the [=subtree=] of a [=skipped=]
+         ''subtree-visibility: hidden'' element can neither be selected nor
+         focused.
 </dl>
 
 Note that when the element is [=skipped=] and the rendering work is avoided,

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-UD" rel="stylesheet" type="text/css">
   <meta content="Bikeshed version b43aa594f5014ff14748da1aace9afaa73d2b3e6" name="generator">
   <link href="https://wicg.github.io/display-locking" rel="canonical">
-  <meta content="7515b77017d7c868998a3daf488b3726673f85cf" name="document-revision">
+  <meta content="357b14a405a3f9508c77903d2ef16fdac30a5edc" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -258,7 +258,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">CSS Subtree Visibility</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Unofficial Proposal Draft, <time class="dt-updated" datetime="2020-03-17">17 March 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Unofficial Proposal Draft, <time class="dt-updated" datetime="2020-03-20">20 March 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -475,7 +475,7 @@ the user-agent must apply <a data-link-type="dfn" href="https://drafts.csswg.org
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="subtree-visibility" data-dfn-type="dfn" data-export id="subtree-visibility-auto">auto</dfn>
     <dd data-md>
      <p>The element <a data-link-type="dfn" href="#gains-containment" id="ref-for-gains-containment">gains containment</a>.
- If *all of* the following conditions hold then the element is also <a data-link-type="dfn" href="#skipped" id="ref-for-skipped">skipped</a>:</p>
+ If <strong>all of</strong> the following conditions hold then the element is also <a data-link-type="dfn" href="#skipped" id="ref-for-skipped">skipped</a>:</p>
      <ul>
       <li data-md>
        <p>The element is <a data-link-type="dfn" href="#off-screen" id="ref-for-off-screen①">off-screen</a>.</p>
@@ -489,93 +489,95 @@ the user-agent must apply <a data-link-type="dfn" href="https://drafts.csswg.org
      </ul>
      <p>It is important to note that the contents of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree⑧">subtree</a> must be
  accessible to user-agent features such as find-in-page, tab order
- navigation, etc. This is true regardless of whether the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①">skipped</a> or not.</p>
+ navigation, etc. This is true regardless of whether the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①">skipped</a> or not. In particular, this means that elements in the <span id="ref-for-subtree⑨">subtree</span> of a <span id="ref-for-skipped②">skipped</span> <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②">subtree-visibility: auto</a> element are
+ able to be focused and selected.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="subtree-visibility" data-dfn-type="dfn" data-export id="subtree-visibility-hidden">hidden</dfn>
     <dd data-md>
-     <p>The element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped②">skipped</a>.</p>
-     <p>Note that in this case, the contents of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree⑨">subtree</a> are not accessible
+     <p>The element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped③">skipped</a>.</p>
+     <p>Note that in this case, the contents of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⓪">subtree</a> are not accessible
  to user-agent features, such as find-in-page, tab order navigation,
- etc.</p>
+ etc. This means that elements in the <span id="ref-for-subtree①①">subtree</span> of a <a data-link-type="dfn" href="#skipped" id="ref-for-skipped④">skipped</a> <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③">subtree-visibility: hidden</a> element can neither be selected nor
+ focused.</p>
    </dl>
-   <p>Note that when the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped③">skipped</a> and the rendering work is avoided,
+   <p>Note that when the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑤">skipped</a> and the rendering work is avoided,
 the user-agent should retain the previously computed layout state if possible.</p>
    <div class="note" role="note">
      Intuitively, a <a data-link-type="dfn" href="#subtree-visibility-hidden" id="ref-for-subtree-visibility-hidden">hidden</a> value means that the element behaves in a way that
-  does not expose the contents of its <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⓪">subtree</a> to the user (but still has an
+  does not expose the contents of its <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①②">subtree</a> to the user (but still has an
   effect on layout, especially in conjunction with `contain-intrinsic-size`).
   Script interactions are required for the content to appear to the user. 
     <p>In contrast, a value of <a data-link-type="dfn" href="#subtree-visibility-auto" id="ref-for-subtree-visibility-auto">auto</a> means that the element behaves as if the
-  contents of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①①">subtree</a> are accessible to the user. The content can be
+  contents of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①③">subtree</a> are accessible to the user. The content can be
   interacted with in the usual ways: scrolling will reveal the content, tab
-  order navigation will visit the <span id="ref-for-subtree①②">subtree</span>, find-in-page will find matches, etc.
-  The fact that <a data-link-type="dfn" href="#off-screen" id="ref-for-off-screen②">off-screen</a> elements with <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②">subtree-visibility: auto</a> are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped④">skipped</a> is a rendering performance optimization.</p>
-    <p>Note that selected and focused elements affected by <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③">subtree-visibility: auto</a> are treated as if they are painted, since users can interact with this
+  order navigation will visit the <span id="ref-for-subtree①④">subtree</span>, find-in-page will find matches, etc.
+  The fact that <a data-link-type="dfn" href="#off-screen" id="ref-for-off-screen②">off-screen</a> elements with <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility④">subtree-visibility: auto</a> are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑥">skipped</a> is a rendering performance optimization.</p>
+    <p>Note that selected and focused elements affected by <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility⑤">subtree-visibility: auto</a> are treated as if they are painted, since users can interact with this
   content when it is off-screen. For example, a user can copy (via a shortcut)
   text that was selected and scrolled off-screen. For this reason, elements and
   subtrees with focus or selection remain painted.</p>
    </div>
-   <div class="note" role="note"> It is worthwhile to note the interaction between <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility④">subtree-visibility</a> and
-  containment: If the element has a <span class="property" id="ref-for-propdef-subtree-visibility⑤">subtree-visibility</span> value other than <a data-link-type="dfn" href="#subtree-visibility-visible" id="ref-for-subtree-visibility-visible">visible</a>, the user-agent enforces <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#style-containment" id="ref-for-style-containment②">style containment</a> and <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#layout-containment" id="ref-for-layout-containment②">layout
-  containment</a> on the element. Additionally, if the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑤">skipped</a>,
+   <div class="note" role="note"> It is worthwhile to note the interaction between <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility⑥">subtree-visibility</a> and
+  containment: If the element has a <span class="property" id="ref-for-propdef-subtree-visibility⑦">subtree-visibility</span> value other than <a data-link-type="dfn" href="#subtree-visibility-visible" id="ref-for-subtree-visibility-visible">visible</a>, the user-agent enforces <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#style-containment" id="ref-for-style-containment②">style containment</a> and <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#layout-containment" id="ref-for-layout-containment②">layout
+  containment</a> on the element. Additionally, if the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑦">skipped</a>,
   then the user-agent also enforces <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#size-containment" id="ref-for-size-containment①">size containment</a>. These containment
   values are added on top of any existing containment values. </div>
    <h2 class="heading settled" data-level="4" id="restrictions"><span class="secno">4. </span><span class="content">Restrictions and Clarifications</span><a class="self-link" href="#restrictions"></a></h2>
    <ul>
     <li data-md>
      <p>In situations where <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#layout-containment" id="ref-for-layout-containment③">layout containment</a> has no effect (e.g. the
-element does not generate a principal box), <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility⑥">subtree-visibility</a> values also
+element does not generate a principal box), <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility⑧">subtree-visibility</a> values also
 have no effect.</p>
     <li data-md>
      <p><a href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements"> Replaced elements</a> do not paint their contents if they
-are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑥">skipped</a> due to <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility⑦">subtree-visibility</a>. That is, the element’s border
+are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑧">skipped</a> due to <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility⑨">subtree-visibility</a>. That is, the element’s border
 and background are painted, but the replaced content -- as described in
 steps 7.1 and 7.2.4 of <a href="https://www.w3.org/TR/CSS21/zindex.html#painting-order">the painting
 order</a> steps -- is not.</p>
     <li data-md>
      <p>From the perspective of an <a href="https://w3c.github.io/IntersectionObserver/">intersection observer</a>,
-elements in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①③">subtree</a> of a <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑦">skipped</a> element are not intersecting the <a href="https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-root">root</a>.
-This is true even if both the root and the target elements are in the <span id="ref-for-subtree①④">subtree</span> of a <span id="ref-for-skipped⑧">skipped</span> element.</p>
+elements in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑤">subtree</a> of a <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑨">skipped</a> element are not intersecting the <a href="https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-root">root</a>.
+This is true even if both the root and the target elements are in the <span id="ref-for-subtree①⑥">subtree</span> of a <span id="ref-for-skipped①⓪">skipped</span> element.</p>
     <li data-md>
      <p>From the perpsective of a <a href="https://drafts.csswg.org/resize-observer/#resize-observer-interface">resize
-observer</a>, elements in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑤">subtree</a> of a <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑨">skipped</a> element do not
+observer</a>, elements in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑦">subtree</a> of a <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①①">skipped</a> element do not
 change their size. If these elements become non-skipped again, the resize
 observation will be delivered if the new size differs from the last size
 used to notify the resize observer.</p>
    </ul>
    <h2 class="heading settled" data-level="5" id="accessibility"><span class="secno">5. </span><span class="content">Accessibility</span><a class="self-link" href="#accessibility"></a></h2>
-   <p>Similar to the way <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility⑧">subtree-visibility</a> affects painted output of the element’s <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑥">subtree</a>, it also affects information exposed to the <a href="https://w3c.github.io/css-aam/#dfn-accessibility-tree">accessibility
+   <p>Similar to the way <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⓪">subtree-visibility</a> affects painted output of the element’s <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑧">subtree</a>, it also affects information exposed to the <a href="https://w3c.github.io/css-aam/#dfn-accessibility-tree">accessibility
 tree</a> and <a href="https://w3c.github.io/css-aam/#dfn-assistive-technology"> assistive technologies</a>:</p>
    <ul>
     <li data-md>
-     <p>Subtrees affected by <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility⑨">subtree-visibility: visible</a> or <span class="css" id="ref-for-propdef-subtree-visibility①⓪">subtree-visibility: auto</span> that are not <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⓪">skipped</a> should be included in the accessibility tree as usual.</p>
+     <p>Subtrees affected by <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①①">subtree-visibility: visible</a> or <span class="css" id="ref-for-propdef-subtree-visibility①②">subtree-visibility: auto</span> that are not <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①②">skipped</a> should be included in the accessibility tree as usual.</p>
     <li data-md>
-     <p>Subtrees of <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①①">skipped</a> elements should not be included in the accessibility tree,
+     <p>Subtrees of <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①③">skipped</a> elements should not be included in the accessibility tree,
 with the following exception:</p>
      <ul>
       <li data-md>
-       <p>Subtrees which are affected by <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①①">subtree-visibility: auto</a> and are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①②">skipped</a> should be also be included in the accessibility tree
+       <p>Subtrees which are affected by <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①③">subtree-visibility: auto</a> and are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①④">skipped</a> should be also be included in the accessibility tree
 subject to the rendering constraints below.</p>
      </ul>
    </ul>
    <div class="note" role="note">
      Since assistive technologies may provide quick access to offscreen elements,
-  it is desirable that elements in <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①②">subtree-visibility: auto</a> subtrees be made
+  it is desirable that elements in <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①④">subtree-visibility: auto</a> subtrees be made
   available to assistive technologies to provide this functionality, since they
   are intended to be observable to users. 
-    <p>Conversely, since elements in <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①③">subtree-visibility: hidden</a> subtrees are not
+    <p>Conversely, since elements in <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑤">subtree-visibility: hidden</a> subtrees are not
   intended to be observable by users, they should not be exposed to assistive
   technology.</p>
    </div>
    <ul>
     <li data-md>
-     <p>The rendering performance of subtrees affected by <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①④">subtree-visibility</a> and
+     <p>The rendering performance of subtrees affected by <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑥">subtree-visibility</a> and
 exposed to assistive technologies must reasonably match the rendering
 performance of the same subtrees exposed to painted output.</p>
    </ul>
    <div class="note" role="note">
      The requirement of rendering performance equivalency stems from privacy
   considerations. It is imperative that the user-agent ensures that a page
-  using <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑤">subtree-visibility</a> cannot use timing information to deduce whether
+  using <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑦">subtree-visibility</a> cannot use timing information to deduce whether
   the user is using assistive technologies. For this reason, the rendering
   performance of information exposed to assistive technologies must be the same
   as the rendering performance of information exposed to painted output. 
@@ -585,7 +587,7 @@ performance of the same subtrees exposed to painted output.</p>
    </div>
    <div class="note" role="note">
      If the user-agent omits rendering work, then it should still make the effort
-  to expose <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑥">subtree-visibility: auto</a> <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①③">skipped</a> elements and their
+  to expose <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑧">subtree-visibility: auto</a> <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑤">skipped</a> elements and their
   subtrees to assistive technology without exposing any of the layout state,
   since it is not available due to omitted work. 
     <p>If such action is not possible, then the user-agent may omit these subtrees
@@ -605,12 +607,12 @@ performance of the same subtrees exposed to painted output.</p>
   ... some content goes here ...
 <c- p>&lt;/</c-><c- f>div</c-><c- p>></c->
 </pre>
-    <p>The .sv element’s <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑦">subtree-visibility</a> value <a data-link-type="dfn" href="#subtree-visibility-auto" id="ref-for-subtree-visibility-auto①">auto</a> lets the user-agent
-  manage whether the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①④">skipped</a>.  Specifically when this element is
+    <p>The .sv element’s <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑨">subtree-visibility</a> value <a data-link-type="dfn" href="#subtree-visibility-auto" id="ref-for-subtree-visibility-auto①">auto</a> lets the user-agent
+  manage whether the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑥">skipped</a>.  Specifically when this element is
   near the viewport, the user-agent will begin painting the element.  When the
   element moves away from the viewport, it will stop being painted. In
   addition, the user-agent should skip as much of the rendering work as
-  possible when the element is <span id="ref-for-skipped①⑤">skipped</span>.</p>
+  possible when the element is <span id="ref-for-skipped①⑦">skipped</span>.</p>
    </div>
    <div class="example" id="example-d9055d5b">
     <a class="self-link" href="#example-d9055d5b"></a> 
@@ -624,12 +626,12 @@ performance of the same subtrees exposed to painted output.</p>
   ... some content goes here ...
 <c- p>&lt;/</c-><c- f>div</c-><c- p>></c->
 </pre>
-    <p>In this case, the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑥">skipped</a> regardless of viewport intersection.
-  This means that the only way to have this <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑦">subtree</a> painted is via script
-  updating the value to remove <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑧">subtree-visibility</a> or change its value. As
-  before, the user-agent should skip as much of the rendering in the <span id="ref-for-subtree①⑧">subtree</span> as
+    <p>In this case, the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑧">skipped</a> regardless of viewport intersection.
+  This means that the only way to have this <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑨">subtree</a> painted is via script
+  updating the value to remove <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⓪">subtree-visibility</a> or change its value. As
+  before, the user-agent should skip as much of the rendering in the <span id="ref-for-subtree②⓪">subtree</span> as
   possible.</p>
-    <p>An additional effect of skipping rendering is that the layout state of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑨">subtree</a> can be preserved by the user-agent, so that removing the <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑨">subtree-visibility</a> property in the future will cause the <span id="ref-for-subtree②⓪">subtree</span> to be
+    <p>An additional effect of skipping rendering is that the layout state of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②①">subtree</a> can be preserved by the user-agent, so that removing the <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②①">subtree-visibility</a> property in the future will cause the <span id="ref-for-subtree②②">subtree</span> to be
   rendered quicker than otherwise possible.</p>
    </div>
    <div class="example" id="example-536d29cb">
@@ -667,9 +669,9 @@ performance of the same subtrees exposed to painted output.</p>
   <c- p>...</c->
 <c- p>&lt;/</c-><c- f>script</c-><c- p>></c->
 </pre>
-    <p>Similarly to the last example, the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑦">skipped</a>. The user-agent
+    <p>Similarly to the last example, the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑨">skipped</a>. The user-agent
   should avoid as much rendering work as possible.  However, in this example,
-  at some point script accesses a layout value in the element’s <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②①">subtree</a>. In
+  at some point script accesses a layout value in the element’s <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②③">subtree</a>. In
   this situation, the user-agent cannot avoid rendering work and has to process
   any previously skipped rendering work in order to return a correct value to
   the caller. In this example, the result of getBoundingClientRect is a rect
@@ -682,40 +684,40 @@ performance of the same subtrees exposed to painted output.</p>
   rendering work.</p>
    </div>
    <h2 class="heading settled" data-level="7" id="similarity"><span class="secno">7. </span><span class="content">Similarity to visibility</span><a class="self-link" href="#similarity"></a></h2>
-   <p>Note that <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⓪">subtree-visibility</a> bears some similarity in naming to <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility">visibility</a> which is important to address. Like <span class="property" id="ref-for-propdef-visibility①">visibility</span>, <span class="property" id="ref-for-propdef-subtree-visibility②①">subtree-visibility</span> controls
-whether the element, or its <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②②">subtree</a>, are painted and hit-tested. However, it
+   <p>Note that <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②②">subtree-visibility</a> bears some similarity in naming to <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility">visibility</a> which is important to address. Like <span class="property" id="ref-for-propdef-visibility①">visibility</span>, <span class="property" id="ref-for-propdef-subtree-visibility②③">subtree-visibility</span> controls
+whether the element, or its <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②④">subtree</a>, are painted and hit-tested. However, it
 has important distinctions that allow both adoption in a wider set of use-cases
 and ability for user-agents to optimize rendering performance:</p>
    <ul>
     <li data-md>
-     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②②">subtree-visibility</a> values cannot be reverted by descendant style. As an
-example, when processing an element that has <span class="property" id="ref-for-propdef-subtree-visibility②③">subtree-visibility</span> value <a data-link-type="dfn" href="#subtree-visibility-hidden" id="ref-for-subtree-visibility-hidden①">hidden</a>, the user-agent will not paint any of its subtree, even if one of
-the elements in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②③">subtree</a> has <span class="property" id="ref-for-propdef-subtree-visibility②④">subtree-visibility</span> value <a data-link-type="dfn" href="#subtree-visibility-visible" id="ref-for-subtree-visibility-visible①">visible</a>. This
+     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②④">subtree-visibility</a> values cannot be reverted by descendant style. As an
+example, when processing an element that has <span class="property" id="ref-for-propdef-subtree-visibility②⑤">subtree-visibility</span> value <a data-link-type="dfn" href="#subtree-visibility-hidden" id="ref-for-subtree-visibility-hidden①">hidden</a>, the user-agent will not paint any of its subtree, even if one of
+the elements in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑤">subtree</a> has <span class="property" id="ref-for-propdef-subtree-visibility②⑥">subtree-visibility</span> value <a data-link-type="dfn" href="#subtree-visibility-visible" id="ref-for-subtree-visibility-visible①">visible</a>. This
 is important as it makes it possible to skip style part of rendering in
-these <span id="ref-for-subtree②④">subtree</span>, since no descendant value can override <span class="property" id="ref-for-propdef-subtree-visibility②⑤">subtree-visibility</span>.</p>
+these <span id="ref-for-subtree②⑥">subtree</span>, since no descendant value can override <span class="property" id="ref-for-propdef-subtree-visibility②⑦">subtree-visibility</span>.</p>
     <li data-md>
-     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑥">subtree-visibility</a> has an <a data-link-type="dfn" href="#subtree-visibility-auto" id="ref-for-subtree-visibility-auto②">auto</a> value, which allows the user-agent to
-paint the element’s <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑤">subtree</a> when it approaches the viewport. This allows easy
+     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑧">subtree-visibility</a> has an <a data-link-type="dfn" href="#subtree-visibility-auto" id="ref-for-subtree-visibility-auto②">auto</a> value, which allows the user-agent to
+paint the element’s <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑦">subtree</a> when it approaches the viewport. This allows easy
 adoption of the feature. In contrast, if <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility②">visibility</a> or <a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display">display: none</a> are
 used instead, then it is up to the developer to toggle the values when they
 approach the viewport.</p>
     <li data-md>
-     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑦">subtree-visibility</a> adds in containment. This is an important part of the
-property, which allows the user-agent to skip rendering work in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑥">subtree</a>,
-since it can reason that when the element’s <span id="ref-for-subtree②⑦">subtree</span> is not painted, then the
-style and layout effects of the <span id="ref-for-subtree②⑧">subtree</span> will not affect any visible content.</p>
+     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑨">subtree-visibility</a> adds in containment. This is an important part of the
+property, which allows the user-agent to skip rendering work in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑧">subtree</a>,
+since it can reason that when the element’s <span id="ref-for-subtree②⑨">subtree</span> is not painted, then the
+style and layout effects of the <span id="ref-for-subtree③⓪">subtree</span> will not affect any visible content.</p>
    </ul>
    <h2 class="heading settled" data-level="8" id="alternatives"><span class="secno">8. </span><span class="content">Alternatives Considered</span><a class="self-link" href="#alternatives"></a></h2>
    <p>The <a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display①">display: none</a> CSS property causes content subtrees not to render.
 However, there is no mechanism for user-agent features to cause these subtrees
 to render. Additionally, the cost of hiding and showing content cannot be
-eliminated since <span class="css" id="ref-for-propdef-display②">display: none</span> does not preserve the layout state of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑨">subtree</a>.</p>
+eliminated since <span class="css" id="ref-for-propdef-display②">display: none</span> does not preserve the layout state of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree③①">subtree</a>.</p>
    <p><a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility③">visibility: hidden</a> causes subtrees to not paint, but they still need style
-and layout, as the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree③⓪">subtree</a> takes up layout space and descendants may be <span class="css" id="ref-for-propdef-visibility④">visibility: visible</span>. Note that with sufficient containment and intersection
-observer, the functionality provided by <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑧">subtree-visibility</a> may be mimicked.
-However, <span class="css" id="ref-for-propdef-subtree-visibility②⑨">subtree-visibility: auto</span> also permits user-agent algorithms such
-as find-in-page and fragment navigation to access the element’s <span id="ref-for-subtree③①">subtree</span>, which
-cannot be mimicked by <span class="css">visibility</span>. Overall, <span class="property" id="ref-for-propdef-subtree-visibility③⓪">subtree-visibility</span> property is
+and layout, as the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree③②">subtree</a> takes up layout space and descendants may be <span class="css" id="ref-for-propdef-visibility④">visibility: visible</span>. Note that with sufficient containment and intersection
+observer, the functionality provided by <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③⓪">subtree-visibility</a> may be mimicked.
+However, <span class="css" id="ref-for-propdef-subtree-visibility③①">subtree-visibility: auto</span> also permits user-agent algorithms such
+as find-in-page and fragment navigation to access the element’s <span id="ref-for-subtree③③">subtree</span>, which
+cannot be mimicked by <span class="css">visibility</span>. Overall, <span class="property" id="ref-for-propdef-subtree-visibility③②">subtree-visibility</span> property is
 a stronger signal allowing the user-agent to optimize rendering.</p>
    <p>Similar to <a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility⑤">visibility: hidden</a>, <a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css-contain-2/#propdef-contain" id="ref-for-propdef-contain①">contain: strict</a> allows the browser to
 automatically detect subtrees that are definitely off-screen, and therefore
@@ -723,7 +725,7 @@ that don’t need to be rendered. However, <span class="css" id="ref-for-propdef
 flexible enough to allow for responsive design layouts that grow elements to
 fit their content. To work around this, content could be marked as ''contain:
 strict'' when off-screen and then some other value when on-screen (this is
-similar to <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③①">subtree-visibility</a>). Second, <span class="css" id="ref-for-propdef-contain③">contain: strict</span> may or may not
+similar to <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③③">subtree-visibility</a>). Second, <span class="css" id="ref-for-propdef-contain③">contain: strict</span> may or may not
 result in rendering work, depending on whether the browser detects the content
 is actually off-screen. Third, it does not support user-agent features in
 cases when it is not actually rendered to the user in the current application
@@ -1001,7 +1003,7 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
       <th scope="col">Com­puted value
     <tbody>
      <tr>
-      <th scope="row"><a class="css" data-link-type="property" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③②">subtree-visibility</a>
+      <th scope="row"><a class="css" data-link-type="property" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③④">subtree-visibility</a>
       <td>visible | auto | hidden
       <td>visible
       <td>all elements
@@ -1017,12 +1019,12 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
    <ul>
     <li><a href="#ref-for-subtree">1.1. Motivation &amp; Background</a> <a href="#ref-for-subtree①">(2)</a> <a href="#ref-for-subtree②">(3)</a>
     <li><a href="#ref-for-subtree③">2. Definitions</a> <a href="#ref-for-subtree④">(2)</a> <a href="#ref-for-subtree⑤">(3)</a>
-    <li><a href="#ref-for-subtree⑥">3. The subtree-visibility property</a> <a href="#ref-for-subtree⑦">(2)</a> <a href="#ref-for-subtree⑧">(3)</a> <a href="#ref-for-subtree⑨">(4)</a> <a href="#ref-for-subtree①⓪">(5)</a> <a href="#ref-for-subtree①①">(6)</a> <a href="#ref-for-subtree①②">(7)</a>
-    <li><a href="#ref-for-subtree①③">4. Restrictions and Clarifications</a> <a href="#ref-for-subtree①④">(2)</a> <a href="#ref-for-subtree①⑤">(3)</a>
-    <li><a href="#ref-for-subtree①⑥">5. Accessibility</a>
-    <li><a href="#ref-for-subtree①⑦">6. Examples</a> <a href="#ref-for-subtree①⑧">(2)</a> <a href="#ref-for-subtree①⑨">(3)</a> <a href="#ref-for-subtree②⓪">(4)</a> <a href="#ref-for-subtree②①">(5)</a>
-    <li><a href="#ref-for-subtree②②">7. Similarity to visibility</a> <a href="#ref-for-subtree②③">(2)</a> <a href="#ref-for-subtree②④">(3)</a> <a href="#ref-for-subtree②⑤">(4)</a> <a href="#ref-for-subtree②⑥">(5)</a> <a href="#ref-for-subtree②⑦">(6)</a> <a href="#ref-for-subtree②⑧">(7)</a>
-    <li><a href="#ref-for-subtree②⑨">8. Alternatives Considered</a> <a href="#ref-for-subtree③⓪">(2)</a> <a href="#ref-for-subtree③①">(3)</a>
+    <li><a href="#ref-for-subtree⑥">3. The subtree-visibility property</a> <a href="#ref-for-subtree⑦">(2)</a> <a href="#ref-for-subtree⑧">(3)</a> <a href="#ref-for-subtree⑨">(4)</a> <a href="#ref-for-subtree①⓪">(5)</a> <a href="#ref-for-subtree①①">(6)</a> <a href="#ref-for-subtree①②">(7)</a> <a href="#ref-for-subtree①③">(8)</a> <a href="#ref-for-subtree①④">(9)</a>
+    <li><a href="#ref-for-subtree①⑤">4. Restrictions and Clarifications</a> <a href="#ref-for-subtree①⑥">(2)</a> <a href="#ref-for-subtree①⑦">(3)</a>
+    <li><a href="#ref-for-subtree①⑧">5. Accessibility</a>
+    <li><a href="#ref-for-subtree①⑨">6. Examples</a> <a href="#ref-for-subtree②⓪">(2)</a> <a href="#ref-for-subtree②①">(3)</a> <a href="#ref-for-subtree②②">(4)</a> <a href="#ref-for-subtree②③">(5)</a>
+    <li><a href="#ref-for-subtree②④">7. Similarity to visibility</a> <a href="#ref-for-subtree②⑤">(2)</a> <a href="#ref-for-subtree②⑥">(3)</a> <a href="#ref-for-subtree②⑦">(4)</a> <a href="#ref-for-subtree②⑧">(5)</a> <a href="#ref-for-subtree②⑨">(6)</a> <a href="#ref-for-subtree③⓪">(7)</a>
+    <li><a href="#ref-for-subtree③①">8. Alternatives Considered</a> <a href="#ref-for-subtree③②">(2)</a> <a href="#ref-for-subtree③③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="off-screen">
@@ -1035,10 +1037,10 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
   <aside class="dfn-panel" data-for="skipped">
    <b><a href="#skipped">#skipped</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-skipped">3. The subtree-visibility property</a> <a href="#ref-for-skipped①">(2)</a> <a href="#ref-for-skipped②">(3)</a> <a href="#ref-for-skipped③">(4)</a> <a href="#ref-for-skipped④">(5)</a> <a href="#ref-for-skipped⑤">(6)</a>
-    <li><a href="#ref-for-skipped⑥">4. Restrictions and Clarifications</a> <a href="#ref-for-skipped⑦">(2)</a> <a href="#ref-for-skipped⑧">(3)</a> <a href="#ref-for-skipped⑨">(4)</a>
-    <li><a href="#ref-for-skipped①⓪">5. Accessibility</a> <a href="#ref-for-skipped①①">(2)</a> <a href="#ref-for-skipped①②">(3)</a> <a href="#ref-for-skipped①③">(4)</a>
-    <li><a href="#ref-for-skipped①④">6. Examples</a> <a href="#ref-for-skipped①⑤">(2)</a> <a href="#ref-for-skipped①⑥">(3)</a> <a href="#ref-for-skipped①⑦">(4)</a>
+    <li><a href="#ref-for-skipped">3. The subtree-visibility property</a> <a href="#ref-for-skipped①">(2)</a> <a href="#ref-for-skipped②">(3)</a> <a href="#ref-for-skipped③">(4)</a> <a href="#ref-for-skipped④">(5)</a> <a href="#ref-for-skipped⑤">(6)</a> <a href="#ref-for-skipped⑥">(7)</a> <a href="#ref-for-skipped⑦">(8)</a>
+    <li><a href="#ref-for-skipped⑧">4. Restrictions and Clarifications</a> <a href="#ref-for-skipped⑨">(2)</a> <a href="#ref-for-skipped①⓪">(3)</a> <a href="#ref-for-skipped①①">(4)</a>
+    <li><a href="#ref-for-skipped①②">5. Accessibility</a> <a href="#ref-for-skipped①③">(2)</a> <a href="#ref-for-skipped①④">(3)</a> <a href="#ref-for-skipped①⑤">(4)</a>
+    <li><a href="#ref-for-skipped①⑥">6. Examples</a> <a href="#ref-for-skipped①⑦">(2)</a> <a href="#ref-for-skipped①⑧">(3)</a> <a href="#ref-for-skipped①⑨">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="gains-containment">
@@ -1051,12 +1053,12 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
    <b><a href="#propdef-subtree-visibility">#propdef-subtree-visibility</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-subtree-visibility">2. Definitions</a>
-    <li><a href="#ref-for-propdef-subtree-visibility①">3. The subtree-visibility property</a> <a href="#ref-for-propdef-subtree-visibility②">(2)</a> <a href="#ref-for-propdef-subtree-visibility③">(3)</a> <a href="#ref-for-propdef-subtree-visibility④">(4)</a> <a href="#ref-for-propdef-subtree-visibility⑤">(5)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility⑥">4. Restrictions and Clarifications</a> <a href="#ref-for-propdef-subtree-visibility⑦">(2)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility⑧">5. Accessibility</a> <a href="#ref-for-propdef-subtree-visibility⑨">(2)</a> <a href="#ref-for-propdef-subtree-visibility①⓪">(3)</a> <a href="#ref-for-propdef-subtree-visibility①①">(4)</a> <a href="#ref-for-propdef-subtree-visibility①②">(5)</a> <a href="#ref-for-propdef-subtree-visibility①③">(6)</a> <a href="#ref-for-propdef-subtree-visibility①④">(7)</a> <a href="#ref-for-propdef-subtree-visibility①⑤">(8)</a> <a href="#ref-for-propdef-subtree-visibility①⑥">(9)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility①⑦">6. Examples</a> <a href="#ref-for-propdef-subtree-visibility①⑧">(2)</a> <a href="#ref-for-propdef-subtree-visibility①⑨">(3)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility②⓪">7. Similarity to visibility</a> <a href="#ref-for-propdef-subtree-visibility②①">(2)</a> <a href="#ref-for-propdef-subtree-visibility②②">(3)</a> <a href="#ref-for-propdef-subtree-visibility②③">(4)</a> <a href="#ref-for-propdef-subtree-visibility②④">(5)</a> <a href="#ref-for-propdef-subtree-visibility②⑤">(6)</a> <a href="#ref-for-propdef-subtree-visibility②⑥">(7)</a> <a href="#ref-for-propdef-subtree-visibility②⑦">(8)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility②⑧">8. Alternatives Considered</a> <a href="#ref-for-propdef-subtree-visibility②⑨">(2)</a> <a href="#ref-for-propdef-subtree-visibility③⓪">(3)</a> <a href="#ref-for-propdef-subtree-visibility③①">(4)</a>
+    <li><a href="#ref-for-propdef-subtree-visibility①">3. The subtree-visibility property</a> <a href="#ref-for-propdef-subtree-visibility②">(2)</a> <a href="#ref-for-propdef-subtree-visibility③">(3)</a> <a href="#ref-for-propdef-subtree-visibility④">(4)</a> <a href="#ref-for-propdef-subtree-visibility⑤">(5)</a> <a href="#ref-for-propdef-subtree-visibility⑥">(6)</a> <a href="#ref-for-propdef-subtree-visibility⑦">(7)</a>
+    <li><a href="#ref-for-propdef-subtree-visibility⑧">4. Restrictions and Clarifications</a> <a href="#ref-for-propdef-subtree-visibility⑨">(2)</a>
+    <li><a href="#ref-for-propdef-subtree-visibility①⓪">5. Accessibility</a> <a href="#ref-for-propdef-subtree-visibility①①">(2)</a> <a href="#ref-for-propdef-subtree-visibility①②">(3)</a> <a href="#ref-for-propdef-subtree-visibility①③">(4)</a> <a href="#ref-for-propdef-subtree-visibility①④">(5)</a> <a href="#ref-for-propdef-subtree-visibility①⑤">(6)</a> <a href="#ref-for-propdef-subtree-visibility①⑥">(7)</a> <a href="#ref-for-propdef-subtree-visibility①⑦">(8)</a> <a href="#ref-for-propdef-subtree-visibility①⑧">(9)</a>
+    <li><a href="#ref-for-propdef-subtree-visibility①⑨">6. Examples</a> <a href="#ref-for-propdef-subtree-visibility②⓪">(2)</a> <a href="#ref-for-propdef-subtree-visibility②①">(3)</a>
+    <li><a href="#ref-for-propdef-subtree-visibility②②">7. Similarity to visibility</a> <a href="#ref-for-propdef-subtree-visibility②③">(2)</a> <a href="#ref-for-propdef-subtree-visibility②④">(3)</a> <a href="#ref-for-propdef-subtree-visibility②⑤">(4)</a> <a href="#ref-for-propdef-subtree-visibility②⑥">(5)</a> <a href="#ref-for-propdef-subtree-visibility②⑦">(6)</a> <a href="#ref-for-propdef-subtree-visibility②⑧">(7)</a> <a href="#ref-for-propdef-subtree-visibility②⑨">(8)</a>
+    <li><a href="#ref-for-propdef-subtree-visibility③⓪">8. Alternatives Considered</a> <a href="#ref-for-propdef-subtree-visibility③①">(2)</a> <a href="#ref-for-propdef-subtree-visibility③②">(3)</a> <a href="#ref-for-propdef-subtree-visibility③③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="subtree-visibility-visible">


### PR DESCRIPTION
Please take a look. It wasn't immediately clear what "the content is available for tab order navigation" meant in the auto, so I added a sentence to both 'hidden' and 'auto' sections to clarify.