### PR TITLE
Added scrollIntoView() and focus() clarifications

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -261,7 +261,7 @@ Restrictions and Clarifications {#restrictions}
       <code>scrollIntoView()</code> brings the targeted element into the
       viewport. This means that elements with ''subtree-visibility: auto'' will
       not be [=skipped=] and thus will not have [=size containment=]
-      automatically applied to them. However, since
+      automatically applied to them after scroll is applied. However, since
       <code>scrollIntoView()</code> first computes the bounds, and
       <em>then</em> brings the element into the viewport, [=size containment=]
       has to be respected when computing the needed scroll position. Note that

--- a/index.bs
+++ b/index.bs
@@ -206,11 +206,11 @@ the user-agent should retain the previously computed layout state if possible.
 Restrictions and Clarifications {#restrictions}
 ===============================
 
-* In situations where [=layout containment=] has no effect (e.g. the
+1. In situations where [=layout containment=] has no effect (e.g. the
     element does not generate a principal box), 'subtree-visibility' values also
     have no effect.
 
-* <a href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements">
+2. <a href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements">
     Replaced elements</a> do not paint their contents if they
     are [=skipped=] due to 'subtree-visibility'. That is, the element's border
     and background are painted, but the replaced content -- as described in
@@ -218,21 +218,21 @@ Restrictions and Clarifications {#restrictions}
     href="https://www.w3.org/TR/CSS21/zindex.html#painting-order">the painting
     order</a> steps -- is not.
 
-* From the perspective of an <a
+3. From the perspective of an <a
     href="https://w3c.github.io/IntersectionObserver/">intersection observer</a>,
     elements in the [=subtree=] of a [=skipped=] element are not intersecting the <a
     href="https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-root">root</a>.
     This is true even if both the root and the target elements are in the [=subtree=]
     of a [=skipped=] element.
 
-* From the perpsective of a <a
+4. From the perpsective of a <a
     href="https://drafts.csswg.org/resize-observer/#resize-observer-interface">resize
     observer</a>, elements in the [=subtree=] of a [=skipped=] element do not
     change their size. If these elements become non-skipped again, the resize
     observation will be delivered if the new size differs from the last size
     used to notify the resize observer.
 
-* When the [=off-screen=] state of an element changes, and if that change
+5. When the [=off-screen=] state of an element changes, and if that change
     affects the [=skipped=] state of the element, then this change will take
     effect after the requestAnimationFrame callbacks of the frame that renders
     the effects of the change have run. Specifically, such changes will take
@@ -251,6 +251,38 @@ Restrictions and Clarifications {#restrictions}
       these two events (internal intersection observation and [=skipped=] state
       update) will retrieve values consistent with current painted state and not cause any forced layouts.
     </div>
+
+6. For an [=off-screen=] element with ''subtree-visibility: auto'' and for
+    elements in its subtree, <a
+    href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview"><code>scrollIntoView()</code></a>
+    computes the element's bounds considering [=size containment=] that is applied
+    on the ''subtree-visibility: auto'' element.
+    <div class=note>
+      <code>scrollIntoView()</code> brings the targetted element into the
+      viewport. This means that elements with ''subtree-visibility: auto'' will
+      not be [=skipped=] and thus will not have [=size containment=]
+      automatically applied to them. However, since
+      <code>scrollIntoView()</code> first computes the bounds, and
+      <em>then</em> brings the element into the viewport, [=size containment=]
+      has to be respected when computing the needed scroll position. Note that
+      this only makes a difference when [=size containment=] changes the
+      element's size from what it would have been without it.
+    </div>
+
+7. When an [=off-screen=] element with ''subtree-visibility: auto'' or any
+    element in its subtree is focused, the focus state applies
+    before the scroll position is determined.
+    <div class=note>
+      Since <code>focus()</code> can bring an element into the viewport, the
+      user-agent needs to compute the elements bounds. However, unlike
+      <code>scrollIntoView()</code>, the focus property applies first, meaning
+      that the element becomes non-[=skipped=] and no longer has [=size
+      containment=] applied at the time the bounds computation is made. Note
+      that this is consistent with the order of <a
+      href="https://html.spec.whatwg.org/multipage/interaction.html#dom-focus"><code>focus()</code></a>
+      specification, and applies for both focus gained via <code>focus()</code>
+      function and user gestures.
+    </note>
 
 Accessibility {#accessibility}
 =============

--- a/index.bs
+++ b/index.bs
@@ -255,7 +255,7 @@ Restrictions and Clarifications {#restrictions}
 6. For an [=off-screen=] element with ''subtree-visibility: auto'' and for
     elements in its subtree, <a
     href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview"><code>scrollIntoView()</code></a>
-    computes the element's bounds considering [=size containment=] that is applied
+    computes the element's bounds with its existing [=size containment=] applied
     on the ''subtree-visibility: auto'' element.
     <div class=note>
       <code>scrollIntoView()</code> brings the targeted element into the

--- a/index.bs
+++ b/index.bs
@@ -258,7 +258,7 @@ Restrictions and Clarifications {#restrictions}
     computes the element's bounds considering [=size containment=] that is applied
     on the ''subtree-visibility: auto'' element.
     <div class=note>
-      <code>scrollIntoView()</code> brings the targetted element into the
+      <code>scrollIntoView()</code> brings the targeted element into the
       viewport. This means that elements with ''subtree-visibility: auto'' will
       not be [=skipped=] and thus will not have [=size containment=]
       automatically applied to them. However, since

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-UD" rel="stylesheet" type="text/css">
   <meta content="Bikeshed version b43aa594f5014ff14748da1aace9afaa73d2b3e6" name="generator">
   <link href="https://wicg.github.io/display-locking" rel="canonical">
-  <meta content="d780282e9f3b2351abb34ab23c6f6e19d93f575f" name="document-revision">
+  <meta content="7c436dcee595c6bb2dd9722aeafbc4afd71dc937" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -524,7 +524,7 @@ the user-agent should retain the previously computed layout state if possible.</
   then the user-agent also enforces <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#size-containment" id="ref-for-size-containment①">size containment</a>. These containment
   values are added on top of any existing containment values. </div>
    <h2 class="heading settled" data-level="4" id="restrictions"><span class="secno">4. </span><span class="content">Restrictions and Clarifications</span><a class="self-link" href="#restrictions"></a></h2>
-   <ul>
+   <ol>
     <li data-md>
      <p>In situations where <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#layout-containment" id="ref-for-layout-containment③">layout containment</a> has no effect (e.g. the
 element does not generate a principal box), <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility⑧">subtree-visibility</a> values also
@@ -562,41 +562,59 @@ the Rendering</a> step of the Processing Model.</p>
   accessing, for example, the containment value of the element between
   these two events (internal intersection observation and <span id="ref-for-skipped①⑤">skipped</span> state
   update) will retrieve values consistent with current painted state and not cause any forced layouts. </div>
-   </ul>
+    <li data-md>
+     <p>For an <a data-link-type="dfn" href="#off-screen" id="ref-for-off-screen④">off-screen</a> element with <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⓪">subtree-visibility: auto</a> and for
+elements in its subtree, <a href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview"><code>scrollIntoView()</code></a> computes the element’s bounds considering <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#size-containment" id="ref-for-size-containment②">size containment</a> that is applied
+on the <span class="css" id="ref-for-propdef-subtree-visibility①①">subtree-visibility: auto</span> element.</p>
+     <div class="note" role="note"> <code>scrollIntoView()</code> brings the targetted element into the
+  viewport. This means that elements with <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①②">subtree-visibility: auto</a> will
+  not be <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑥">skipped</a> and thus will not have <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#size-containment" id="ref-for-size-containment③">size containment</a> automatically applied to them. However, since <code>scrollIntoView()</code> first computes the bounds, and <em>then</em> brings the element into the viewport, <span id="ref-for-size-containment④">size containment</span> has to be respected when computing the needed scroll position. Note that
+  this only makes a difference when <span id="ref-for-size-containment⑤">size containment</span> changes the
+  element’s size from what it would have been without it. </div>
+    <li data-md>
+     <p>When an <a data-link-type="dfn" href="#off-screen" id="ref-for-off-screen⑤">off-screen</a> element with <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①③">subtree-visibility: auto</a> or any
+element in its subtree is focused, the focus state applies
+before the scroll position is determined.</p>
+     <div class="note" role="note"> Since <code>focus()</code> can bring an element into the viewport, the
+  user-agent needs to compute the elements bounds. However, unlike <code>scrollIntoView()</code>, the focus property applies first, meaning
+  that the element becomes non-<a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑦">skipped</a> and no longer has <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#size-containment" id="ref-for-size-containment⑥">size
+  containment</a> applied at the time the bounds computation is made. Note
+  that this is consistent with the order of <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-focus"><code>focus()</code></a> specification, and applies for both focus gained via <code>focus()</code> function and user gestures. </div>
+   </ol>
    <h2 class="heading settled" data-level="5" id="accessibility"><span class="secno">5. </span><span class="content">Accessibility</span><a class="self-link" href="#accessibility"></a></h2>
-   <p>Similar to the way <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⓪">subtree-visibility</a> affects painted output of the element’s <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑧">subtree</a>, it also affects information exposed to the <a href="https://w3c.github.io/css-aam/#dfn-accessibility-tree">accessibility
+   <p>Similar to the way <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①④">subtree-visibility</a> affects painted output of the element’s <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑧">subtree</a>, it also affects information exposed to the <a href="https://w3c.github.io/css-aam/#dfn-accessibility-tree">accessibility
 tree</a> and <a href="https://w3c.github.io/css-aam/#dfn-assistive-technology"> assistive technologies</a>:</p>
    <ul>
     <li data-md>
-     <p>Subtrees affected by <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①①">subtree-visibility: visible</a> or <span class="css" id="ref-for-propdef-subtree-visibility①②">subtree-visibility: auto</span> that are not <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑥">skipped</a> should be included in the accessibility tree as usual.</p>
+     <p>Subtrees affected by <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑤">subtree-visibility: visible</a> or <span class="css" id="ref-for-propdef-subtree-visibility①⑥">subtree-visibility: auto</span> that are not <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑧">skipped</a> should be included in the accessibility tree as usual.</p>
     <li data-md>
-     <p>Subtrees of <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑦">skipped</a> elements should not be included in the accessibility tree,
+     <p>Subtrees of <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑨">skipped</a> elements should not be included in the accessibility tree,
 with the following exception:</p>
      <ul>
       <li data-md>
-       <p>Subtrees which are affected by <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①③">subtree-visibility: auto</a> and are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑧">skipped</a> should be also be included in the accessibility tree
+       <p>Subtrees which are affected by <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑦">subtree-visibility: auto</a> and are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped②⓪">skipped</a> should be also be included in the accessibility tree
 subject to the rendering constraints below.</p>
      </ul>
    </ul>
    <div class="note" role="note">
      Since assistive technologies may provide quick access to offscreen elements,
-  it is desirable that elements in <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①④">subtree-visibility: auto</a> subtrees be made
+  it is desirable that elements in <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑧">subtree-visibility: auto</a> subtrees be made
   available to assistive technologies to provide this functionality, since they
   are intended to be observable to users. 
-    <p>Conversely, since elements in <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑤">subtree-visibility: hidden</a> subtrees are not
+    <p>Conversely, since elements in <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑨">subtree-visibility: hidden</a> subtrees are not
   intended to be observable by users, they should not be exposed to assistive
   technology.</p>
    </div>
    <ul>
     <li data-md>
-     <p>The rendering performance of subtrees affected by <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑥">subtree-visibility</a> and
+     <p>The rendering performance of subtrees affected by <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⓪">subtree-visibility</a> and
 exposed to assistive technologies must reasonably match the rendering
 performance of the same subtrees exposed to painted output.</p>
    </ul>
    <div class="note" role="note">
      The requirement of rendering performance equivalency stems from privacy
   considerations. It is imperative that the user-agent ensures that a page
-  using <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑦">subtree-visibility</a> cannot use timing information to deduce whether
+  using <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②①">subtree-visibility</a> cannot use timing information to deduce whether
   the user is using assistive technologies. For this reason, the rendering
   performance of information exposed to assistive technologies must be the same
   as the rendering performance of information exposed to painted output. 
@@ -606,7 +624,7 @@ performance of the same subtrees exposed to painted output.</p>
    </div>
    <div class="note" role="note">
      If the user-agent omits rendering work, then it should still make the effort
-  to expose <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑧">subtree-visibility: auto</a> <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑨">skipped</a> elements and their
+  to expose <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②②">subtree-visibility: auto</a> <a data-link-type="dfn" href="#skipped" id="ref-for-skipped②①">skipped</a> elements and their
   subtrees to assistive technology without exposing any of the layout state,
   since it is not available due to omitted work. 
     <p>If such action is not possible, then the user-agent may omit these subtrees
@@ -626,12 +644,12 @@ performance of the same subtrees exposed to painted output.</p>
   ... some content goes here ...
 <c- p>&lt;/</c-><c- f>div</c-><c- p>></c->
 </pre>
-    <p>The .sv element’s <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑨">subtree-visibility</a> value <a data-link-type="dfn" href="#subtree-visibility-auto" id="ref-for-subtree-visibility-auto①">auto</a> lets the user-agent
-  manage whether the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped②⓪">skipped</a>.  Specifically when this element is
+    <p>The .sv element’s <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②③">subtree-visibility</a> value <a data-link-type="dfn" href="#subtree-visibility-auto" id="ref-for-subtree-visibility-auto①">auto</a> lets the user-agent
+  manage whether the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped②②">skipped</a>.  Specifically when this element is
   near the viewport, the user-agent will begin painting the element.  When the
   element moves away from the viewport, it will stop being painted. In
   addition, the user-agent should skip as much of the rendering work as
-  possible when the element is <span id="ref-for-skipped②①">skipped</span>.</p>
+  possible when the element is <span id="ref-for-skipped②③">skipped</span>.</p>
    </div>
    <div class="example" id="example-d9055d5b">
     <a class="self-link" href="#example-d9055d5b"></a> 
@@ -645,12 +663,12 @@ performance of the same subtrees exposed to painted output.</p>
   ... some content goes here ...
 <c- p>&lt;/</c-><c- f>div</c-><c- p>></c->
 </pre>
-    <p>In this case, the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped②②">skipped</a> regardless of viewport intersection.
+    <p>In this case, the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped②④">skipped</a> regardless of viewport intersection.
   This means that the only way to have this <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑨">subtree</a> painted is via script
-  updating the value to remove <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⓪">subtree-visibility</a> or change its value. As
+  updating the value to remove <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②④">subtree-visibility</a> or change its value. As
   before, the user-agent should skip as much of the rendering in the <span id="ref-for-subtree②⓪">subtree</span> as
   possible.</p>
-    <p>An additional effect of skipping rendering is that the layout state of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②①">subtree</a> can be preserved by the user-agent, so that removing the <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②①">subtree-visibility</a> property in the future will cause the <span id="ref-for-subtree②②">subtree</span> to be
+    <p>An additional effect of skipping rendering is that the layout state of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②①">subtree</a> can be preserved by the user-agent, so that removing the <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑤">subtree-visibility</a> property in the future will cause the <span id="ref-for-subtree②②">subtree</span> to be
   rendered quicker than otherwise possible.</p>
    </div>
    <div class="example" id="example-536d29cb">
@@ -688,7 +706,7 @@ performance of the same subtrees exposed to painted output.</p>
   <c- p>...</c->
 <c- p>&lt;/</c-><c- f>script</c-><c- p>></c->
 </pre>
-    <p>Similarly to the last example, the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped②③">skipped</a>. The user-agent
+    <p>Similarly to the last example, the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped②⑤">skipped</a>. The user-agent
   should avoid as much rendering work as possible.  However, in this example,
   at some point script accesses a layout value in the element’s <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②③">subtree</a>. In
   this situation, the user-agent cannot avoid rendering work and has to process
@@ -703,25 +721,25 @@ performance of the same subtrees exposed to painted output.</p>
   rendering work.</p>
    </div>
    <h2 class="heading settled" data-level="7" id="similarity"><span class="secno">7. </span><span class="content">Similarity to visibility</span><a class="self-link" href="#similarity"></a></h2>
-   <p>Note that <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②②">subtree-visibility</a> bears some similarity in naming to <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility">visibility</a> which is important to address. Like <span class="property" id="ref-for-propdef-visibility①">visibility</span>, <span class="property" id="ref-for-propdef-subtree-visibility②③">subtree-visibility</span> controls
+   <p>Note that <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑥">subtree-visibility</a> bears some similarity in naming to <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility">visibility</a> which is important to address. Like <span class="property" id="ref-for-propdef-visibility①">visibility</span>, <span class="property" id="ref-for-propdef-subtree-visibility②⑦">subtree-visibility</span> controls
 whether the element, or its <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②④">subtree</a>, are painted and hit-tested. However, it
 has important distinctions that allow both adoption in a wider set of use-cases
 and ability for user-agents to optimize rendering performance:</p>
    <ul>
     <li data-md>
-     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②④">subtree-visibility</a> values cannot be reverted by descendant style. As an
-example, when processing an element that has <span class="property" id="ref-for-propdef-subtree-visibility②⑤">subtree-visibility</span> value <a data-link-type="dfn" href="#subtree-visibility-hidden" id="ref-for-subtree-visibility-hidden①">hidden</a>, the user-agent will not paint any of its subtree, even if one of
-the elements in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑤">subtree</a> has <span class="property" id="ref-for-propdef-subtree-visibility②⑥">subtree-visibility</span> value <a data-link-type="dfn" href="#subtree-visibility-visible" id="ref-for-subtree-visibility-visible①">visible</a>. This
+     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑧">subtree-visibility</a> values cannot be reverted by descendant style. As an
+example, when processing an element that has <span class="property" id="ref-for-propdef-subtree-visibility②⑨">subtree-visibility</span> value <a data-link-type="dfn" href="#subtree-visibility-hidden" id="ref-for-subtree-visibility-hidden①">hidden</a>, the user-agent will not paint any of its subtree, even if one of
+the elements in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑤">subtree</a> has <span class="property" id="ref-for-propdef-subtree-visibility③⓪">subtree-visibility</span> value <a data-link-type="dfn" href="#subtree-visibility-visible" id="ref-for-subtree-visibility-visible①">visible</a>. This
 is important as it makes it possible to skip style part of rendering in
-these <span id="ref-for-subtree②⑥">subtree</span>, since no descendant value can override <span class="property" id="ref-for-propdef-subtree-visibility②⑦">subtree-visibility</span>.</p>
+these <span id="ref-for-subtree②⑥">subtree</span>, since no descendant value can override <span class="property" id="ref-for-propdef-subtree-visibility③①">subtree-visibility</span>.</p>
     <li data-md>
-     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑧">subtree-visibility</a> has an <a data-link-type="dfn" href="#subtree-visibility-auto" id="ref-for-subtree-visibility-auto②">auto</a> value, which allows the user-agent to
+     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③②">subtree-visibility</a> has an <a data-link-type="dfn" href="#subtree-visibility-auto" id="ref-for-subtree-visibility-auto②">auto</a> value, which allows the user-agent to
 paint the element’s <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑦">subtree</a> when it approaches the viewport. This allows easy
 adoption of the feature. In contrast, if <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility②">visibility</a> or <a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display">display: none</a> are
 used instead, then it is up to the developer to toggle the values when they
 approach the viewport.</p>
     <li data-md>
-     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑨">subtree-visibility</a> adds in containment. This is an important part of the
+     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③③">subtree-visibility</a> adds in containment. This is an important part of the
 property, which allows the user-agent to skip rendering work in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑧">subtree</a>,
 since it can reason that when the element’s <span id="ref-for-subtree②⑨">subtree</span> is not painted, then the
 style and layout effects of the <span id="ref-for-subtree③⓪">subtree</span> will not affect any visible content.</p>
@@ -733,10 +751,10 @@ to render. Additionally, the cost of hiding and showing content cannot be
 eliminated since <span class="css" id="ref-for-propdef-display②">display: none</span> does not preserve the layout state of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree③①">subtree</a>.</p>
    <p><a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility③">visibility: hidden</a> causes subtrees to not paint, but they still need style
 and layout, as the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree③②">subtree</a> takes up layout space and descendants may be <span class="css" id="ref-for-propdef-visibility④">visibility: visible</span>. Note that with sufficient containment and intersection
-observer, the functionality provided by <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③⓪">subtree-visibility</a> may be mimicked.
-However, <span class="css" id="ref-for-propdef-subtree-visibility③①">subtree-visibility: auto</span> also permits user-agent algorithms such
+observer, the functionality provided by <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③④">subtree-visibility</a> may be mimicked.
+However, <span class="css" id="ref-for-propdef-subtree-visibility③⑤">subtree-visibility: auto</span> also permits user-agent algorithms such
 as find-in-page and fragment navigation to access the element’s <span id="ref-for-subtree③③">subtree</span>, which
-cannot be mimicked by <span class="css">visibility</span>. Overall, <span class="property" id="ref-for-propdef-subtree-visibility③②">subtree-visibility</span> property is
+cannot be mimicked by <span class="css">visibility</span>. Overall, <span class="property" id="ref-for-propdef-subtree-visibility③⑥">subtree-visibility</span> property is
 a stronger signal allowing the user-agent to optimize rendering.</p>
    <p>Similar to <a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility⑤">visibility: hidden</a>, <a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css-contain-2/#propdef-contain" id="ref-for-propdef-contain①">contain: strict</a> allows the browser to
 automatically detect subtrees that are definitely off-screen, and therefore
@@ -744,7 +762,7 @@ that don’t need to be rendered. However, <span class="css" id="ref-for-propdef
 flexible enough to allow for responsive design layouts that grow elements to
 fit their content. To work around this, content could be marked as ''contain:
 strict'' when off-screen and then some other value when on-screen (this is
-similar to <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③③">subtree-visibility</a>). Second, <span class="css" id="ref-for-propdef-contain③">contain: strict</span> may or may not
+similar to <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③⑦">subtree-visibility</a>). Second, <span class="css" id="ref-for-propdef-contain③">contain: strict</span> may or may not
 result in rendering work, depending on whether the browser detects the content
 is actually off-screen. Third, it does not support user-agent features in
 cases when it is not actually rendered to the user in the current application
@@ -897,6 +915,7 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
    <ul>
     <li><a href="#ref-for-size-containment">2. Definitions</a>
     <li><a href="#ref-for-size-containment①">3. The subtree-visibility property</a>
+    <li><a href="#ref-for-size-containment②">4. Restrictions and Clarifications</a> <a href="#ref-for-size-containment③">(2)</a> <a href="#ref-for-size-containment④">(3)</a> <a href="#ref-for-size-containment⑤">(4)</a> <a href="#ref-for-size-containment⑥">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-style-containment">
@@ -1022,7 +1041,7 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
       <th scope="col">Com­puted value
     <tbody>
      <tr>
-      <th scope="row"><a class="css" data-link-type="property" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③④">subtree-visibility</a>
+      <th scope="row"><a class="css" data-link-type="property" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③⑧">subtree-visibility</a>
       <td>visible | auto | hidden
       <td>visible
       <td>all elements
@@ -1051,16 +1070,16 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
    <ul>
     <li><a href="#ref-for-off-screen">2. Definitions</a>
     <li><a href="#ref-for-off-screen①">3. The subtree-visibility property</a> <a href="#ref-for-off-screen②">(2)</a>
-    <li><a href="#ref-for-off-screen③">4. Restrictions and Clarifications</a>
+    <li><a href="#ref-for-off-screen③">4. Restrictions and Clarifications</a> <a href="#ref-for-off-screen④">(2)</a> <a href="#ref-for-off-screen⑤">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="skipped">
    <b><a href="#skipped">#skipped</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-skipped">3. The subtree-visibility property</a> <a href="#ref-for-skipped①">(2)</a> <a href="#ref-for-skipped②">(3)</a> <a href="#ref-for-skipped③">(4)</a> <a href="#ref-for-skipped④">(5)</a> <a href="#ref-for-skipped⑤">(6)</a> <a href="#ref-for-skipped⑥">(7)</a> <a href="#ref-for-skipped⑦">(8)</a>
-    <li><a href="#ref-for-skipped⑧">4. Restrictions and Clarifications</a> <a href="#ref-for-skipped⑨">(2)</a> <a href="#ref-for-skipped①⓪">(3)</a> <a href="#ref-for-skipped①①">(4)</a> <a href="#ref-for-skipped①②">(5)</a> <a href="#ref-for-skipped①③">(6)</a> <a href="#ref-for-skipped①④">(7)</a> <a href="#ref-for-skipped①⑤">(8)</a>
-    <li><a href="#ref-for-skipped①⑥">5. Accessibility</a> <a href="#ref-for-skipped①⑦">(2)</a> <a href="#ref-for-skipped①⑧">(3)</a> <a href="#ref-for-skipped①⑨">(4)</a>
-    <li><a href="#ref-for-skipped②⓪">6. Examples</a> <a href="#ref-for-skipped②①">(2)</a> <a href="#ref-for-skipped②②">(3)</a> <a href="#ref-for-skipped②③">(4)</a>
+    <li><a href="#ref-for-skipped⑧">4. Restrictions and Clarifications</a> <a href="#ref-for-skipped⑨">(2)</a> <a href="#ref-for-skipped①⓪">(3)</a> <a href="#ref-for-skipped①①">(4)</a> <a href="#ref-for-skipped①②">(5)</a> <a href="#ref-for-skipped①③">(6)</a> <a href="#ref-for-skipped①④">(7)</a> <a href="#ref-for-skipped①⑤">(8)</a> <a href="#ref-for-skipped①⑥">(9)</a> <a href="#ref-for-skipped①⑦">(10)</a>
+    <li><a href="#ref-for-skipped①⑧">5. Accessibility</a> <a href="#ref-for-skipped①⑨">(2)</a> <a href="#ref-for-skipped②⓪">(3)</a> <a href="#ref-for-skipped②①">(4)</a>
+    <li><a href="#ref-for-skipped②②">6. Examples</a> <a href="#ref-for-skipped②③">(2)</a> <a href="#ref-for-skipped②④">(3)</a> <a href="#ref-for-skipped②⑤">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="gains-containment">
@@ -1074,11 +1093,11 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
    <ul>
     <li><a href="#ref-for-propdef-subtree-visibility">2. Definitions</a>
     <li><a href="#ref-for-propdef-subtree-visibility①">3. The subtree-visibility property</a> <a href="#ref-for-propdef-subtree-visibility②">(2)</a> <a href="#ref-for-propdef-subtree-visibility③">(3)</a> <a href="#ref-for-propdef-subtree-visibility④">(4)</a> <a href="#ref-for-propdef-subtree-visibility⑤">(5)</a> <a href="#ref-for-propdef-subtree-visibility⑥">(6)</a> <a href="#ref-for-propdef-subtree-visibility⑦">(7)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility⑧">4. Restrictions and Clarifications</a> <a href="#ref-for-propdef-subtree-visibility⑨">(2)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility①⓪">5. Accessibility</a> <a href="#ref-for-propdef-subtree-visibility①①">(2)</a> <a href="#ref-for-propdef-subtree-visibility①②">(3)</a> <a href="#ref-for-propdef-subtree-visibility①③">(4)</a> <a href="#ref-for-propdef-subtree-visibility①④">(5)</a> <a href="#ref-for-propdef-subtree-visibility①⑤">(6)</a> <a href="#ref-for-propdef-subtree-visibility①⑥">(7)</a> <a href="#ref-for-propdef-subtree-visibility①⑦">(8)</a> <a href="#ref-for-propdef-subtree-visibility①⑧">(9)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility①⑨">6. Examples</a> <a href="#ref-for-propdef-subtree-visibility②⓪">(2)</a> <a href="#ref-for-propdef-subtree-visibility②①">(3)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility②②">7. Similarity to visibility</a> <a href="#ref-for-propdef-subtree-visibility②③">(2)</a> <a href="#ref-for-propdef-subtree-visibility②④">(3)</a> <a href="#ref-for-propdef-subtree-visibility②⑤">(4)</a> <a href="#ref-for-propdef-subtree-visibility②⑥">(5)</a> <a href="#ref-for-propdef-subtree-visibility②⑦">(6)</a> <a href="#ref-for-propdef-subtree-visibility②⑧">(7)</a> <a href="#ref-for-propdef-subtree-visibility②⑨">(8)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility③⓪">8. Alternatives Considered</a> <a href="#ref-for-propdef-subtree-visibility③①">(2)</a> <a href="#ref-for-propdef-subtree-visibility③②">(3)</a> <a href="#ref-for-propdef-subtree-visibility③③">(4)</a>
+    <li><a href="#ref-for-propdef-subtree-visibility⑧">4. Restrictions and Clarifications</a> <a href="#ref-for-propdef-subtree-visibility⑨">(2)</a> <a href="#ref-for-propdef-subtree-visibility①⓪">(3)</a> <a href="#ref-for-propdef-subtree-visibility①①">(4)</a> <a href="#ref-for-propdef-subtree-visibility①②">(5)</a> <a href="#ref-for-propdef-subtree-visibility①③">(6)</a>
+    <li><a href="#ref-for-propdef-subtree-visibility①④">5. Accessibility</a> <a href="#ref-for-propdef-subtree-visibility①⑤">(2)</a> <a href="#ref-for-propdef-subtree-visibility①⑥">(3)</a> <a href="#ref-for-propdef-subtree-visibility①⑦">(4)</a> <a href="#ref-for-propdef-subtree-visibility①⑧">(5)</a> <a href="#ref-for-propdef-subtree-visibility①⑨">(6)</a> <a href="#ref-for-propdef-subtree-visibility②⓪">(7)</a> <a href="#ref-for-propdef-subtree-visibility②①">(8)</a> <a href="#ref-for-propdef-subtree-visibility②②">(9)</a>
+    <li><a href="#ref-for-propdef-subtree-visibility②③">6. Examples</a> <a href="#ref-for-propdef-subtree-visibility②④">(2)</a> <a href="#ref-for-propdef-subtree-visibility②⑤">(3)</a>
+    <li><a href="#ref-for-propdef-subtree-visibility②⑥">7. Similarity to visibility</a> <a href="#ref-for-propdef-subtree-visibility②⑦">(2)</a> <a href="#ref-for-propdef-subtree-visibility②⑧">(3)</a> <a href="#ref-for-propdef-subtree-visibility②⑨">(4)</a> <a href="#ref-for-propdef-subtree-visibility③⓪">(5)</a> <a href="#ref-for-propdef-subtree-visibility③①">(6)</a> <a href="#ref-for-propdef-subtree-visibility③②">(7)</a> <a href="#ref-for-propdef-subtree-visibility③③">(8)</a>
+    <li><a href="#ref-for-propdef-subtree-visibility③④">8. Alternatives Considered</a> <a href="#ref-for-propdef-subtree-visibility③⑤">(2)</a> <a href="#ref-for-propdef-subtree-visibility③⑥">(3)</a> <a href="#ref-for-propdef-subtree-visibility③⑦">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="subtree-visibility-visible">

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-UD" rel="stylesheet" type="text/css">
   <meta content="Bikeshed version b43aa594f5014ff14748da1aace9afaa73d2b3e6" name="generator">
   <link href="https://wicg.github.io/display-locking" rel="canonical">
-  <meta content="7c436dcee595c6bb2dd9722aeafbc4afd71dc937" name="document-revision">
+  <meta content="b7820107ea77f50cb1260a00f168342deeff9435" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -258,7 +258,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">CSS Subtree Visibility</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Unofficial Proposal Draft, <time class="dt-updated" datetime="2020-03-25">25 March 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Unofficial Proposal Draft, <time class="dt-updated" datetime="2020-03-26">26 March 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -564,11 +564,11 @@ the Rendering</a> step of the Processing Model.</p>
   update) will retrieve values consistent with current painted state and not cause any forced layouts. </div>
     <li data-md>
      <p>For an <a data-link-type="dfn" href="#off-screen" id="ref-for-off-screen④">off-screen</a> element with <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⓪">subtree-visibility: auto</a> and for
-elements in its subtree, <a href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview"><code>scrollIntoView()</code></a> computes the element’s bounds considering <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#size-containment" id="ref-for-size-containment②">size containment</a> that is applied
+elements in its subtree, <a href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview"><code>scrollIntoView()</code></a> computes the element’s bounds with its existing <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#size-containment" id="ref-for-size-containment②">size containment</a> applied
 on the <span class="css" id="ref-for-propdef-subtree-visibility①①">subtree-visibility: auto</span> element.</p>
-     <div class="note" role="note"> <code>scrollIntoView()</code> brings the targetted element into the
+     <div class="note" role="note"> <code>scrollIntoView()</code> brings the targeted element into the
   viewport. This means that elements with <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①②">subtree-visibility: auto</a> will
-  not be <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑥">skipped</a> and thus will not have <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#size-containment" id="ref-for-size-containment③">size containment</a> automatically applied to them. However, since <code>scrollIntoView()</code> first computes the bounds, and <em>then</em> brings the element into the viewport, <span id="ref-for-size-containment④">size containment</span> has to be respected when computing the needed scroll position. Note that
+  not be <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑥">skipped</a> and thus will not have <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#size-containment" id="ref-for-size-containment③">size containment</a> automatically applied to them after scroll is applied. However, since <code>scrollIntoView()</code> first computes the bounds, and <em>then</em> brings the element into the viewport, <span id="ref-for-size-containment④">size containment</span> has to be respected when computing the needed scroll position. Note that
   this only makes a difference when <span id="ref-for-size-containment⑤">size containment</span> changes the
   element’s size from what it would have been without it. </div>
     <li data-md>


### PR DESCRIPTION
Please take a look.

This one has a bunch of links, so for now you can see the rendered output here:
https://vmpstr.github.io/display-locking/#restrictions

I also numbered the clarifications and restrictions to make it easier to refer to.