### PR TITLE
rename to content-visibility

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,6 +1,6 @@
 <pre class='metadata'>
-Title: CSS Subtree Visibility
-Shortname: css-subtree-visibility
+Title: CSS Content Visibility
+Shortname: css-content-visibility
 Level: 1
 Status: UD
 Group: csswg
@@ -8,8 +8,8 @@ Work Status: exploring
 URL: https://wicg.github.io/display-locking
 Editor: Tab Atkins-Bittner, Google
 Editor: Vladimir Levin, Google
-Abstract: This spec introduces a subtree-visibility CSS property, allowing authors
-          to control element subtree visibility, while at the same time providing strong
+Abstract: This spec introduces a content-visibility CSS property, allowing authors
+          to control element content visibility, while at the same time providing strong
           rendering performance hints to the user-agent. The user-agent can use the hints
           to optimize rendering performance, making interactions with large amounts of
           content perform well.
@@ -18,7 +18,7 @@ Abstract: This spec introduces a subtree-visibility CSS property, allowing autho
 Introduction {#intro}
 ============
 
-Subtree Visibility (a.k.a. Display Locking) is a CSS property designed to allow
+Content Visibility (a.k.a. Display Locking) is a CSS property designed to allow
 developers and browsers to easily scale to large amount of content and provide
 strong hints which allow the user-agent to delay rendering <a href=#f1>[1]</a>
 work.  More concretely, the goals are:
@@ -93,8 +93,8 @@ Definitions {#definitions}
 * <dfn export>subtree</dfn>: an element's subtree are all nodes that comprise
     the [=flattened element tree=] rooted at the given element, with the exception
     of the element itself. In other words, this refers to the [=flat tree=]
-    descendants of the element. Note that the term <em>subtree</em> in the
-    property name 'subtree-visibility' refers to the same descendants.
+    descendants of the element. Note that the term <em>content</em> in the
+    property name 'content-visibility' refers to the same descendants.
 * <dfn export>off-screen</dfn>: an element is considered to be off-screen if
     its border box does not intersect the visual viewport plus a user-agent
     specified, margin.
@@ -128,17 +128,17 @@ Definitions {#definitions}
     the user-agent must apply [=layout containment=], [=style containment=],
     and [=paint containment=] to it in addition to any other containment properties.
 
-The 'subtree-visibility' property {#subtree-visibility}
+The 'content-visibility' property {#content-visibility}
 =================================
 
 <pre class=propdef>
-Name: subtree-visibility
+Name: content-visibility
 Value: visible | auto | hidden
 Initial: visible
 Inherited: no
 </pre>
 
-<dl dfn-type value dfn-for=subtree-visibility>
+<dl dfn-type value dfn-for=content-visibility>
     : <dfn export>visible</dfn>
     :: No effect. This provides no extra information or hints to the user-agent.
 
@@ -159,7 +159,7 @@ Inherited: no
          accessible to user-agent features such as find-in-page, tab order
          navigation, etc. This is true regardless of whether the element is
          [=skipped=] or not. In particular, this means that elements in the
-         [=subtree=] of a [=skipped=] ''subtree-visibility: auto'' element are
+         [=subtree=] of a [=skipped=] ''content-visibility: auto'' element are
          able to be focused and selected.
 
     : <dfn export>hidden</dfn>
@@ -168,7 +168,7 @@ Inherited: no
          Note that in this case, the contents of the [=subtree=] are not accessible
          to user-agent features, such as find-in-page, tab order navigation,
          etc. This means that elements in the [=subtree=] of a [=skipped=]
-         ''subtree-visibility: hidden'' element can neither be selected nor
+         ''content-visibility: hidden'' element can neither be selected nor
          focused.
 </dl>
 
@@ -185,10 +185,10 @@ the user-agent should retain the previously computed layout state if possible.
   contents of the [=subtree=] are accessible to the user. The content can be
   interacted with in the usual ways: scrolling will reveal the content, tab
   order navigation will visit the [=subtree=], find-in-page will find matches, etc.
-  The fact that some [=off-screen=] elements with ''subtree-visibility: auto'' are
+  The fact that some [=off-screen=] elements with ''content-visibility: auto'' are
   [=skipped=] is a rendering performance optimization.
 
-  Note that selected and focused elements affected by ''subtree-visibility:
+  Note that selected and focused elements affected by ''content-visibility:
   auto'' are not [=skipped=], since users can interact with this content when
   it is off-screen. For example, a user can copy (via a shortcut) text that was
   selected and scrolled off-screen. For this reason, elements and subtrees with
@@ -196,15 +196,15 @@ the user-agent should retain the previously computed layout state if possible.
 </div>
 
 <div class=note>
-  It is worthwhile to note the interaction between 'subtree-visibility' and
-  containment: If the element has a 'subtree-visibility' value other than
+  It is worthwhile to note the interaction between 'content-visibility' and
+  containment: If the element has a 'content-visibility' value other than
   [=visible=], the user-agent enforces [=style containment=], [=layout
   containment=], and [=paint containment=] on the element. Additionally, if the
   element is [=skipped=], then the user-agent also enforces [=size
   containment=]. These containment values are added on top of any existing
   containment values.
 
-  If a container element is an element which has a 'subtree-visibility' value
+  If a container element is an element which has a 'content-visibility' value
   that adds containment, then the following properties hold:
 
   * [=layout containment=] ensures that the user-agent is able to omit layout
@@ -219,9 +219,9 @@ the user-agent should retain the previously computed layout state if possible.
   * [=paint containment=] ensures that [=ink overflow=] of painted contents is
       clipped; this, in turn, means that user-agent can reliably determine when
       the visible portion of the element approaches the viewport and start
-      painting it (in the ''subtree-visibility: auto'' case).
+      painting it (in the ''content-visibility: auto'' case).
 
-  Note that in the ''subtree-visibility: auto'' case, [=layout containment=],
+  Note that in the ''content-visibility: auto'' case, [=layout containment=],
   [=style containment=], and [=paint containment=] persist even if the element
   is not [=skipped=]. This is done to prevent layout changes that would be
   incurred by containment changes as a result element entering and exiting the
@@ -232,12 +232,12 @@ Restrictions and Clarifications {#restrictions}
 ===============================
 
 1. In situations where [=layout containment=] has no effect (e.g. the
-    element does not generate a principal box), 'subtree-visibility' values also
+    element does not generate a principal box), 'content-visibility' values also
     have no effect.
 
 2. <a href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements">
     Replaced elements</a> do not paint their contents if they
-    are [=skipped=] due to 'subtree-visibility'. That is, the element's border
+    are [=skipped=] due to 'content-visibility'. That is, the element's border
     and background are painted, but the replaced content -- as described in
     steps 7.1 and 7.2.4 of <a
     href="https://www.w3.org/TR/CSS21/zindex.html#painting-order">the painting
@@ -278,14 +278,14 @@ Restrictions and Clarifications {#restrictions}
       not cause any forced layouts.
     </div>
 
-6. For an [=off-screen=] element with ''subtree-visibility: auto'' and for
+6. For an [=off-screen=] element with ''content-visibility: auto'' and for
     elements in its subtree, <a
     href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview"><code>scrollIntoView()</code></a>
     computes the element's bounds with its existing [=size containment=] applied
-    on the ''subtree-visibility: auto'' element.
+    on the ''content-visibility: auto'' element.
     <div class=note>
       <code>scrollIntoView()</code> brings the targeted element into the
-      viewport. This means that elements with ''subtree-visibility: auto'' will
+      viewport. This means that elements with ''content-visibility: auto'' will
       not be [=skipped=] and thus will not have [=size containment=]
       automatically applied to them after scroll is applied. However, since
       <code>scrollIntoView()</code> first computes the bounds, and
@@ -295,7 +295,7 @@ Restrictions and Clarifications {#restrictions}
       element's size from what it would have been without it.
     </div>
 
-7. When an [=off-screen=] element with ''subtree-visibility: auto'' or any
+7. When an [=off-screen=] element with ''content-visibility: auto'' or any
     element in its subtree is focused, the focus state applies
     before the scroll position is determined.
     <div class=note>
@@ -334,38 +334,38 @@ Restrictions and Clarifications {#restrictions}
 Accessibility {#accessibility}
 =============
 
-Similar to the way 'subtree-visibility' affects painted output of the element's
+Similar to the way 'content-visibility' affects painted output of the element's
 [=subtree=], it also affects information exposed to the
 <a href="https://w3c.github.io/css-aam/#dfn-accessibility-tree">accessibility
 tree</a> and <a href="https://w3c.github.io/css-aam/#dfn-assistive-technology">
 assistive technologies</a>:
-* Subtrees affected by ''subtree-visibility: visible'' or ''subtree-visibility: auto''
+* Subtrees affected by ''content-visibility: visible'' or ''content-visibility: auto''
     that are not [=skipped=] should be included in the accessibility tree as usual.
 * Subtrees of [=skipped=] elements should not be included in the accessibility tree,
     with the following exception:
-    * Subtrees which are affected by ''subtree-visibility: auto'' and are
+    * Subtrees which are affected by ''content-visibility: auto'' and are
         [=skipped=] should be also be included in the accessibility tree
         subject to the rendering constraints below.
 
 <div class=note>
   Since assistive technologies may provide quick access to offscreen elements,
-  it is desirable that elements in ''subtree-visibility: auto'' subtrees be made
+  it is desirable that elements in ''content-visibility: auto'' subtrees be made
   available to assistive technologies to provide this functionality, since they
   are intended to be observable to users.
 
-  Conversely, since elements in ''subtree-visibility: hidden'' subtrees are not
+  Conversely, since elements in ''content-visibility: hidden'' subtrees are not
   intended to be observable by users, they should not be exposed to assistive
   technology.
 </div>
 
-* The rendering performance of subtrees affected by 'subtree-visibility' and
+* The rendering performance of subtrees affected by 'content-visibility' and
     exposed to assistive technologies must reasonably match the rendering
     performance of the same subtrees exposed to painted output.
 
 <div class=note>
   The requirement of rendering performance equivalency stems from privacy
   considerations. It is imperative that the user-agent ensures that a page
-  using 'subtree-visibility' cannot use timing information to deduce whether
+  using 'content-visibility' cannot use timing information to deduce whether
   the user is using assistive technologies. For this reason, the rendering
   performance of information exposed to assistive technologies must be the same
   as the rendering performance of information exposed to painted output.
@@ -377,7 +377,7 @@ assistive technologies</a>:
 
 <div class=note>
   If the user-agent omits rendering work, then it should still make the effort
-  to expose ''subtree-visibility: auto'' [=skipped=] elements and their
+  to expose ''content-visibility: auto'' [=skipped=] elements and their
   subtrees to assistive technology without exposing any of the layout state,
   since it is not available due to omitted work.
 
@@ -402,7 +402,7 @@ with any personally identifiable or sensitive information. Hence, the risk to
 the user is low.
 
 It may seem that a cross-origin iframe can learn that it is offscreen, and
-under a subtree-visibility hidden or auto ancestor, by noticing that
+under a content-visibility hidden or auto ancestor, by noticing that
 requestAnimationFrame callbacks are not run. However, since user-agents are
 already <a
 href="https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity">allowed
@@ -410,7 +410,7 @@ to throttle</a> or stop generating frames for off-screen cross-origin iframes
 and since [=skipped=] element's descendants are not intersecting the viewport
 from an IntersectionObserver perspective, the fact that
 requestionAnimationFrame callbacks are not run is insufficient information to
-detect 'subtree-visibility' ancestors.
+detect 'content-visibility' ancestors.
 
 Examples {#examples}
 ========
@@ -419,7 +419,7 @@ Examples {#examples}
 	<xmp highlight=markup>
 		<style>
 		.sv {
-		  subtree-visibility: auto;
+		  content-visibility: auto;
       min-height: 50px;
 		}
 		</style>
@@ -429,7 +429,7 @@ Examples {#examples}
 		</div>
 	</xmp>
 
-  The .sv element's 'subtree-visibility' value [=auto=] lets the user-agent
+  The .sv element's 'content-visibility' value [=auto=] lets the user-agent
   manage whether the element is [=skipped=].  Specifically when this element is
   near the viewport, the user-agent will begin painting the element.  When the
   element moves away from the viewport, it will stop being painted. In
@@ -441,7 +441,7 @@ Examples {#examples}
 	<xmp highlight=markup>
 		<style>
 		.sv {
-		  subtree-visibility: hidden;
+		  content-visibility: hidden;
 		}
 		</style>
 
@@ -452,13 +452,13 @@ Examples {#examples}
 
   In this case, the element is [=skipped=] regardless of viewport intersection.
   This means that the only way to have this [=subtree=] painted is via script
-  updating the value to remove 'subtree-visibility' or change its value. As
+  updating the value to remove 'content-visibility' or change its value. As
   before, the user-agent should skip as much of the rendering in the [=subtree=] as
   possible.
 
   An additional effect of skipping rendering is that the layout state of the
   [=subtree=] can be preserved by the user-agent, so that removing the
-  'subtree-visibility' property in the future will cause the [=subtree=] to be
+  'content-visibility' property in the future will cause the [=subtree=] to be
   rendered quicker than otherwise possible.
 </div>
 
@@ -469,7 +469,7 @@ Examples {#examples}
       margin: 0;
     }
 		.sv {
-		  subtree-visibility: hidden;
+		  content-visibility: hidden;
 
       position: relative;
       left: 10px;
@@ -518,24 +518,24 @@ Examples {#examples}
 Similarity to visibility {#similarity}
 ========================
 
-Note that 'subtree-visibility' bears some similarity in naming to 'visibility'
-which is important to address. Like 'visibility', 'subtree-visibility' controls
+Note that 'content-visibility' bears some similarity in naming to 'visibility'
+which is important to address. Like 'visibility', 'content-visibility' controls
 whether the element, or its [=subtree=], are painted and hit-tested. However, it
 has important distinctions that allow both adoption in a wider set of use-cases
 and ability for user-agents to optimize rendering performance:
 
-* 'subtree-visibility' values cannot be reverted by descendant style. As an
-    example, when processing an element that has 'subtree-visibility' value
+* 'content-visibility' values cannot be reverted by descendant style. As an
+    example, when processing an element that has 'content-visibility' value
     [=hidden=], the user-agent will not paint any of its subtree, even if one of
-    the elements in the [=subtree=] has 'subtree-visibility' value [=visible=]. This
+    the elements in the [=subtree=] has 'content-visibility' value [=visible=]. This
     is important as it makes it possible to skip style part of rendering in
-    these [=subtree=], since no descendant value can override 'subtree-visibility'.
-* 'subtree-visibility' has an [=auto=] value, which allows the user-agent to
+    these [=subtree=], since no descendant value can override 'content-visibility'.
+* 'content-visibility' has an [=auto=] value, which allows the user-agent to
     paint the element's [=subtree=] when it approaches the viewport. This allows easy
     adoption of the feature. In contrast, if 'visibility' or ''display: none'' are
     used instead, then it is up to the developer to toggle the values when they
     approach the viewport.
-* 'subtree-visibility' adds in containment. This is an important part of the
+* 'content-visibility' adds in containment. This is an important part of the
     property, which allows the user-agent to skip rendering work in the [=subtree=],
     since it can reason that when the element's [=subtree=] is not painted, then the
     style and layout effects of the [=subtree=] will not affect any visible content.
@@ -552,10 +552,10 @@ eliminated since ''display: none'' does not preserve the layout state of the
 ''visibility: hidden'' causes subtrees to not paint, but they still need style
 and layout, as the [=subtree=] takes up layout space and descendants may be
 ''visibility: visible''. Note that with sufficient containment and intersection
-observer, the functionality provided by 'subtree-visibility' may be mimicked.
-However, ''subtree-visibility: auto'' also permits user-agent algorithms such
+observer, the functionality provided by 'content-visibility' may be mimicked.
+However, ''content-visibility: auto'' also permits user-agent algorithms such
 as find-in-page and fragment navigation to access the element's [=subtree=], which
-cannot be mimicked by ''visibility''. Overall, 'subtree-visibility' property is
+cannot be mimicked by ''visibility''. Overall, 'content-visibility' property is
 a stronger signal allowing the user-agent to optimize rendering.
 
 Similar to ''visibility: hidden'', ''contain: strict'' allows the browser to
@@ -564,7 +564,7 @@ that don't need to be rendered. However, ''contain: strict'' on its own is not
 flexible enough to allow for responsive design layouts that grow elements to
 fit their content. To work around this, content could be marked as ''contain:
 strict'' when off-screen and then some other value when on-screen (this is
-similar to 'subtree-visibility'). Second, ''contain: strict'' may or may not
+similar to 'content-visibility'). Second, ''contain: strict'' may or may not
 result in rendering work, depending on whether the browser detects the content
 is actually off-screen. Third, it does not support user-agent features in
 cases when it is not actually rendered to the user in the current application

--- a/index.html
+++ b/index.html
@@ -1,17 +1,17 @@
 <!doctype html><html lang="en">
  <head>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-  <title>CSS Subtree Visibility</title>
+  <title>CSS Content Visibility</title>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <meta content="exploring" name="csswg-work-status">
   <meta content="UD" name="w3c-status">
-  <meta content="This spec introduces a subtree-visibility CSS property, allowing authors            to control element subtree visibility, while at the same time providing strong            rendering performance hints to the user-agent. The user-agent can use the hints            to optimize rendering performance, making interactions with large amounts of            content perform well." name="abstract">
+  <meta content="This spec introduces a content-visibility CSS property, allowing authors            to control element content visibility, while at the same time providing strong            rendering performance hints to the user-agent. The user-agent can use the hints            to optimize rendering performance, making interactions with large amounts of            content perform well." name="abstract">
   <link href="../default.css" rel="stylesheet" type="text/css">
   <link href="../csslogo.ico" rel="shortcut icon" type="image/x-icon">
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-UD" rel="stylesheet" type="text/css">
   <meta content="Bikeshed version b43aa594f5014ff14748da1aace9afaa73d2b3e6" name="generator">
   <link href="https://wicg.github.io/display-locking" rel="canonical">
-  <meta content="5dd10bdb4e11548592f71c1b1c10a11453fe8565" name="document-revision">
+  <meta content="7e1a1f38a40c857aa72ac0ce1ab7b172e314fa42" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -257,8 +257,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
-   <h1 class="p-name no-ref" id="title">CSS Subtree Visibility</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Unofficial Proposal Draft, <time class="dt-updated" datetime="2020-04-16">16 April 2020</time></span></h2>
+   <h1 class="p-name no-ref" id="title">CSS Content Visibility</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Unofficial Proposal Draft, <time class="dt-updated" datetime="2020-04-24">24 April 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -267,9 +267,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd class="editor p-author h-card vcard"><span class="p-name fn">Tab Atkins-Bittner</span> (<span class="p-org org">Google</span>)
      <dd class="editor p-author h-card vcard"><span class="p-name fn">Vladimir Levin</span> (<span class="p-org org">Google</span>)
      <dt>Suggest an Edit for this Spec:
-     <dd><a href="https://github.com/w3c/csswg-drafts/blob/master/css-subtree-visibility-1/Overview.bs">GitHub Editor</a>
+     <dd><a href="https://github.com/w3c/csswg-drafts/blob/master/css-content-visibility-1/Overview.bs">GitHub Editor</a>
      <dt>Issue Tracking:
-     <dd><a href="https://github.com/w3c/csswg-drafts/labels/css-subtree-visibility-1">GitHub Issues</a>
+     <dd><a href="https://github.com/w3c/csswg-drafts/labels/css-content-visibility-1">GitHub Issues</a>
     </dl>
    </div>
    <div data-fill-with="warning"></div>
@@ -278,9 +278,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-   <p>This spec introduces a subtree-visibility CSS property, allowing authors
+   <p>This spec introduces a content-visibility CSS property, allowing authors
 
-          to control element subtree visibility, while at the same time providing strong
+          to control element content visibility, while at the same time providing strong
           rendering performance hints to the user-agent. The user-agent can use the hints
           to optimize rendering performance, making interactions with large amounts of
           content perform well.</p>
@@ -302,7 +302,7 @@ on screen, on paper, etc.
       <li><a href="#motivation"><span class="secno">1.1</span> <span class="content">Motivation &amp; Background</span></a>
      </ol>
     <li><a href="#definitions"><span class="secno">2</span> <span class="content">Definitions</span></a>
-    <li><a href="#subtree-visibility"><span class="secno">3</span> <span class="content">The <span class="property">subtree-visibility</span> property</span></a>
+    <li><a href="#content-visibility"><span class="secno">3</span> <span class="content">The <span class="property">content-visibility</span> property</span></a>
     <li><a href="#restrictions"><span class="secno">4</span> <span class="content">Restrictions and Clarifications</span></a>
     <li><a href="#accessibility"><span class="secno">5</span> <span class="content">Accessibility</span></a>
     <li><a href="#priv-sec"><span class="secno">6</span> <span class="content">Privacy &amp; Security Considerations</span></a>
@@ -340,7 +340,7 @@ on screen, on paper, etc.
   </nav>
   <main>
    <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
-   <p>Subtree Visibility (a.k.a. Display Locking) is a CSS property designed to allow
+   <p>Content Visibility (a.k.a. Display Locking) is a CSS property designed to allow
 developers and browsers to easily scale to large amount of content and provide
 strong hints which allow the user-agent to delay rendering <a href="#f1">[1]</a> work.  More concretely, the goals are:</p>
    <ul>
@@ -410,8 +410,8 @@ the document.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="subtree">subtree</dfn>: an element’s subtree are all nodes that comprise
 the <a data-link-type="dfn" href="https://drafts.csswg.org/css-scoping-1/#flat-tree" id="ref-for-flat-tree">flattened element tree</a> rooted at the given element, with the exception
-of the element itself. In other words, this refers to the <span id="ref-for-flat-tree①">flat tree</span> descendants of the element. Note that the term <em>subtree</em> in the
-property name <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility">subtree-visibility</a> refers to the same descendants.</p>
+of the element itself. In other words, this refers to the <span id="ref-for-flat-tree①">flat tree</span> descendants of the element. Note that the term <em>content</em> in the
+property name <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility">content-visibility</a> refers to the same descendants.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="off-screen">off-screen</dfn>: an element is considered to be off-screen if
 its border box does not intersect the visual viewport plus a user-agent
@@ -440,12 +440,12 @@ The user-agent should avoid as much rendering work in the skipped element’s <s
 the user-agent must apply <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#layout-containment" id="ref-for-layout-containment①">layout containment</a>, <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#style-containment" id="ref-for-style-containment①">style containment</a>,
 and <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#paint-containment" id="ref-for-paint-containment①">paint containment</a> to it in addition to any other containment properties.</p>
    </ul>
-   <h2 class="heading settled" data-level="3" id="subtree-visibility"><span class="secno">3. </span><span class="content">The <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①">subtree-visibility</a> property</span><a class="self-link" href="#subtree-visibility"></a></h2>
-   <table class="def propdef" data-link-for-hint="subtree-visibility">
+   <h2 class="heading settled" data-level="3" id="content-visibility"><span class="secno">3. </span><span class="content">The <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility①">content-visibility</a> property</span><a class="self-link" href="#content-visibility"></a></h2>
+   <table class="def propdef" data-link-for-hint="content-visibility">
     <tbody>
      <tr>
       <th>Name:
-      <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export id="propdef-subtree-visibility">subtree-visibility</dfn>
+      <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export id="propdef-content-visibility">content-visibility</dfn>
      <tr class="value">
       <th><a href="https://drafts.csswg.org/css-values/#value-defs">Value:</a>
       <td class="prod">visible <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one">|</a> auto <span id="ref-for-comb-one①">|</span> hidden
@@ -472,10 +472,10 @@ and <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#paint-
       <td>discrete
    </table>
    <dl value>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="subtree-visibility" data-dfn-type="dfn" data-export id="subtree-visibility-visible">visible</dfn>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="content-visibility" data-dfn-type="dfn" data-export id="content-visibility-visible">visible</dfn>
     <dd data-md>
      <p>No effect. This provides no extra information or hints to the user-agent.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="subtree-visibility" data-dfn-type="dfn" data-export id="subtree-visibility-auto">auto</dfn>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="content-visibility" data-dfn-type="dfn" data-export id="content-visibility-auto">auto</dfn>
     <dd data-md>
      <p>The element <a data-link-type="dfn" href="#gains-containment" id="ref-for-gains-containment">gains containment</a>.
  If <strong>all of</strong> the following conditions hold then the element is also <a data-link-type="dfn" href="#skipped" id="ref-for-skipped">skipped</a>:</p>
@@ -492,42 +492,42 @@ and <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#paint-
      </ul>
      <p>It is important to note that the contents of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree⑧">subtree</a> must be
  accessible to user-agent features such as find-in-page, tab order
- navigation, etc. This is true regardless of whether the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①">skipped</a> or not. In particular, this means that elements in the <span id="ref-for-subtree⑨">subtree</span> of a <span id="ref-for-skipped②">skipped</span> <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②">subtree-visibility: auto</a> element are
+ navigation, etc. This is true regardless of whether the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①">skipped</a> or not. In particular, this means that elements in the <span id="ref-for-subtree⑨">subtree</span> of a <span id="ref-for-skipped②">skipped</span> <a class="css" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility②">content-visibility: auto</a> element are
  able to be focused and selected.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="subtree-visibility" data-dfn-type="dfn" data-export id="subtree-visibility-hidden">hidden</dfn>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="content-visibility" data-dfn-type="dfn" data-export id="content-visibility-hidden">hidden</dfn>
     <dd data-md>
      <p>The element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped③">skipped</a>.</p>
      <p>Note that in this case, the contents of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⓪">subtree</a> are not accessible
  to user-agent features, such as find-in-page, tab order navigation,
- etc. This means that elements in the <span id="ref-for-subtree①①">subtree</span> of a <a data-link-type="dfn" href="#skipped" id="ref-for-skipped④">skipped</a> <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③">subtree-visibility: hidden</a> element can neither be selected nor
+ etc. This means that elements in the <span id="ref-for-subtree①①">subtree</span> of a <a data-link-type="dfn" href="#skipped" id="ref-for-skipped④">skipped</a> <a class="css" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility③">content-visibility: hidden</a> element can neither be selected nor
  focused.</p>
    </dl>
    <p>Note that when the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑤">skipped</a> and the rendering work is avoided,
 the user-agent should retain the previously computed layout state if possible.</p>
    <div class="note" role="note">
-     Intuitively, a <a data-link-type="dfn" href="#subtree-visibility-hidden" id="ref-for-subtree-visibility-hidden">hidden</a> value means that the element behaves in a way that
+     Intuitively, a <a data-link-type="dfn" href="#content-visibility-hidden" id="ref-for-content-visibility-hidden">hidden</a> value means that the element behaves in a way that
   does not expose the contents of its <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①②">subtree</a> to the user (but still has an
   effect on layout, especially in conjunction with `contain-intrinsic-size`).
   Script interactions are required for the content to appear to the user. 
-    <p>In contrast, a value of <a data-link-type="dfn" href="#subtree-visibility-auto" id="ref-for-subtree-visibility-auto">auto</a> means that the element behaves as if the
+    <p>In contrast, a value of <a data-link-type="dfn" href="#content-visibility-auto" id="ref-for-content-visibility-auto">auto</a> means that the element behaves as if the
   contents of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①③">subtree</a> are accessible to the user. The content can be
   interacted with in the usual ways: scrolling will reveal the content, tab
   order navigation will visit the <span id="ref-for-subtree①④">subtree</span>, find-in-page will find matches, etc.
-  The fact that some <a data-link-type="dfn" href="#off-screen" id="ref-for-off-screen②">off-screen</a> elements with <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility④">subtree-visibility: auto</a> are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑥">skipped</a> is a rendering performance optimization.</p>
-    <p>Note that selected and focused elements affected by ''subtree-visibility:
+  The fact that some <a data-link-type="dfn" href="#off-screen" id="ref-for-off-screen②">off-screen</a> elements with <a class="css" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility④">content-visibility: auto</a> are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑥">skipped</a> is a rendering performance optimization.</p>
+    <p>Note that selected and focused elements affected by ''content-visibility:
   auto'' are not <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑦">skipped</a>, since users can interact with this content when
   it is off-screen. For example, a user can copy (via a shortcut) text that was
   selected and scrolled off-screen. For this reason, elements and subtrees with
   focus or selection remain not <span id="ref-for-skipped⑧">skipped</span>.</p>
    </div>
    <div class="note" role="note">
-     It is worthwhile to note the interaction between <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility⑤">subtree-visibility</a> and
-  containment: If the element has a <span class="property" id="ref-for-propdef-subtree-visibility⑥">subtree-visibility</span> value other than <a data-link-type="dfn" href="#subtree-visibility-visible" id="ref-for-subtree-visibility-visible">visible</a>, the user-agent enforces <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#style-containment" id="ref-for-style-containment②">style containment</a>, <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#layout-containment" id="ref-for-layout-containment②">layout
+     It is worthwhile to note the interaction between <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility⑤">content-visibility</a> and
+  containment: If the element has a <span class="property" id="ref-for-propdef-content-visibility⑥">content-visibility</span> value other than <a data-link-type="dfn" href="#content-visibility-visible" id="ref-for-content-visibility-visible">visible</a>, the user-agent enforces <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#style-containment" id="ref-for-style-containment②">style containment</a>, <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#layout-containment" id="ref-for-layout-containment②">layout
   containment</a>, and <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#paint-containment" id="ref-for-paint-containment②">paint containment</a> on the element. Additionally, if the
   element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped⑨">skipped</a>, then the user-agent also enforces <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#size-containment" id="ref-for-size-containment①">size
   containment</a>. These containment values are added on top of any existing
   containment values. 
-    <p>If a container element is an element which has a <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility⑦">subtree-visibility</a> value
+    <p>If a container element is an element which has a <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility⑦">content-visibility</a> value
   that adds containment, then the following properties hold:</p>
     <ul>
      <li data-md>
@@ -544,9 +544,9 @@ the user-agent should retain the previously computed layout state if possible.</
       <p><a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#paint-containment" id="ref-for-paint-containment③">paint containment</a> ensures that <a data-link-type="dfn" href="https://drafts.csswg.org/css-overflow-3/#ink-overflow" id="ref-for-ink-overflow">ink overflow</a> of painted contents is
   clipped; this, in turn, means that user-agent can reliably determine when
   the visible portion of the element approaches the viewport and start
-  painting it (in the <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility⑧">subtree-visibility: auto</a> case).</p>
+  painting it (in the <a class="css" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility⑧">content-visibility: auto</a> case).</p>
     </ul>
-    <p>Note that in the <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility⑨">subtree-visibility: auto</a> case, <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#layout-containment" id="ref-for-layout-containment④">layout containment</a>, <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#style-containment" id="ref-for-style-containment④">style containment</a>, and <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#paint-containment" id="ref-for-paint-containment④">paint containment</a> persist even if the element
+    <p>Note that in the <a class="css" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility⑨">content-visibility: auto</a> case, <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#layout-containment" id="ref-for-layout-containment④">layout containment</a>, <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#style-containment" id="ref-for-style-containment④">style containment</a>, and <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#paint-containment" id="ref-for-paint-containment④">paint containment</a> persist even if the element
   is not <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①③">skipped</a>. This is done to prevent layout changes that would be
   incurred by containment changes as a result element entering and exiting the <span id="ref-for-skipped①④">skipped</span> state.</p>
    </div>
@@ -554,11 +554,11 @@ the user-agent should retain the previously computed layout state if possible.</
    <ol>
     <li data-md>
      <p>In situations where <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#layout-containment" id="ref-for-layout-containment⑤">layout containment</a> has no effect (e.g. the
-element does not generate a principal box), <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⓪">subtree-visibility</a> values also
+element does not generate a principal box), <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility①⓪">content-visibility</a> values also
 have no effect.</p>
     <li data-md>
      <p><a href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements"> Replaced elements</a> do not paint their contents if they
-are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑤">skipped</a> due to <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①①">subtree-visibility</a>. That is, the element’s border
+are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped①⑤">skipped</a> due to <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility①①">content-visibility</a>. That is, the element’s border
 and background are painted, but the replaced content -- as described in
 steps 7.1 and 7.2.4 of <a href="https://www.w3.org/TR/CSS21/zindex.html#painting-order">the painting
 order</a> steps -- is not.</p>
@@ -591,16 +591,16 @@ the Rendering</a> step of the Processing Model.</p>
   update) will retrieve values consistent with current painted state and
   not cause any forced layouts. </div>
     <li data-md>
-     <p>For an <a data-link-type="dfn" href="#off-screen" id="ref-for-off-screen④">off-screen</a> element with <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①②">subtree-visibility: auto</a> and for
+     <p>For an <a data-link-type="dfn" href="#off-screen" id="ref-for-off-screen④">off-screen</a> element with <a class="css" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility①②">content-visibility: auto</a> and for
 elements in its subtree, <a href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview"><code>scrollIntoView()</code></a> computes the element’s bounds with its existing <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#size-containment" id="ref-for-size-containment③">size containment</a> applied
-on the <span class="css" id="ref-for-propdef-subtree-visibility①③">subtree-visibility: auto</span> element.</p>
+on the <span class="css" id="ref-for-propdef-content-visibility①③">content-visibility: auto</span> element.</p>
      <div class="note" role="note"> <code>scrollIntoView()</code> brings the targeted element into the
-  viewport. This means that elements with <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①④">subtree-visibility: auto</a> will
+  viewport. This means that elements with <a class="css" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility①④">content-visibility: auto</a> will
   not be <a data-link-type="dfn" href="#skipped" id="ref-for-skipped②③">skipped</a> and thus will not have <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#size-containment" id="ref-for-size-containment④">size containment</a> automatically applied to them after scroll is applied. However, since <code>scrollIntoView()</code> first computes the bounds, and <em>then</em> brings the element into the viewport, <span id="ref-for-size-containment⑤">size containment</span> has to be respected when computing the needed scroll position. Note that
   this only makes a difference when <span id="ref-for-size-containment⑥">size containment</span> changes the
   element’s size from what it would have been without it. </div>
     <li data-md>
-     <p>When an <a data-link-type="dfn" href="#off-screen" id="ref-for-off-screen⑤">off-screen</a> element with <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑤">subtree-visibility: auto</a> or any
+     <p>When an <a data-link-type="dfn" href="#off-screen" id="ref-for-off-screen⑤">off-screen</a> element with <a class="css" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility①⑤">content-visibility: auto</a> or any
 element in its subtree is focused, the focus state applies
 before the scroll position is determined.</p>
      <div class="note" role="note"> Since <code>focus()</code> can bring an element into the viewport, the
@@ -625,39 +625,39 @@ if possible (see note below).</p>
 to the result of <a href="https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute">innerText</a>.</p>
    </ol>
    <h2 class="heading settled" data-level="5" id="accessibility"><span class="secno">5. </span><span class="content">Accessibility</span><a class="self-link" href="#accessibility"></a></h2>
-   <p>Similar to the way <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑥">subtree-visibility</a> affects painted output of the element’s <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑧">subtree</a>, it also affects information exposed to the <a href="https://w3c.github.io/css-aam/#dfn-accessibility-tree">accessibility
+   <p>Similar to the way <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility①⑥">content-visibility</a> affects painted output of the element’s <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑧">subtree</a>, it also affects information exposed to the <a href="https://w3c.github.io/css-aam/#dfn-accessibility-tree">accessibility
 tree</a> and <a href="https://w3c.github.io/css-aam/#dfn-assistive-technology"> assistive technologies</a>:</p>
    <ul>
     <li data-md>
-     <p>Subtrees affected by <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑦">subtree-visibility: visible</a> or <span class="css" id="ref-for-propdef-subtree-visibility①⑧">subtree-visibility: auto</span> that are not <a data-link-type="dfn" href="#skipped" id="ref-for-skipped②⑨">skipped</a> should be included in the accessibility tree as usual.</p>
+     <p>Subtrees affected by <a class="css" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility①⑦">content-visibility: visible</a> or <span class="css" id="ref-for-propdef-content-visibility①⑧">content-visibility: auto</span> that are not <a data-link-type="dfn" href="#skipped" id="ref-for-skipped②⑨">skipped</a> should be included in the accessibility tree as usual.</p>
     <li data-md>
      <p>Subtrees of <a data-link-type="dfn" href="#skipped" id="ref-for-skipped③⓪">skipped</a> elements should not be included in the accessibility tree,
 with the following exception:</p>
      <ul>
       <li data-md>
-       <p>Subtrees which are affected by <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility①⑨">subtree-visibility: auto</a> and are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped③①">skipped</a> should be also be included in the accessibility tree
+       <p>Subtrees which are affected by <a class="css" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility①⑨">content-visibility: auto</a> and are <a data-link-type="dfn" href="#skipped" id="ref-for-skipped③①">skipped</a> should be also be included in the accessibility tree
 subject to the rendering constraints below.</p>
      </ul>
    </ul>
    <div class="note" role="note">
      Since assistive technologies may provide quick access to offscreen elements,
-  it is desirable that elements in <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⓪">subtree-visibility: auto</a> subtrees be made
+  it is desirable that elements in <a class="css" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility②⓪">content-visibility: auto</a> subtrees be made
   available to assistive technologies to provide this functionality, since they
   are intended to be observable to users. 
-    <p>Conversely, since elements in <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②①">subtree-visibility: hidden</a> subtrees are not
+    <p>Conversely, since elements in <a class="css" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility②①">content-visibility: hidden</a> subtrees are not
   intended to be observable by users, they should not be exposed to assistive
   technology.</p>
    </div>
    <ul>
     <li data-md>
-     <p>The rendering performance of subtrees affected by <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②②">subtree-visibility</a> and
+     <p>The rendering performance of subtrees affected by <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility②②">content-visibility</a> and
 exposed to assistive technologies must reasonably match the rendering
 performance of the same subtrees exposed to painted output.</p>
    </ul>
    <div class="note" role="note">
      The requirement of rendering performance equivalency stems from privacy
   considerations. It is imperative that the user-agent ensures that a page
-  using <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②③">subtree-visibility</a> cannot use timing information to deduce whether
+  using <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility②③">content-visibility</a> cannot use timing information to deduce whether
   the user is using assistive technologies. For this reason, the rendering
   performance of information exposed to assistive technologies must be the same
   as the rendering performance of information exposed to painted output. 
@@ -667,7 +667,7 @@ performance of the same subtrees exposed to painted output.</p>
    </div>
    <div class="note" role="note">
      If the user-agent omits rendering work, then it should still make the effort
-  to expose <a class="css" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②④">subtree-visibility: auto</a> <a data-link-type="dfn" href="#skipped" id="ref-for-skipped③②">skipped</a> elements and their
+  to expose <a class="css" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility②④">content-visibility: auto</a> <a data-link-type="dfn" href="#skipped" id="ref-for-skipped③②">skipped</a> elements and their
   subtrees to assistive technology without exposing any of the layout state,
   since it is not available due to omitted work. 
     <p>If such action is not possible, then the user-agent may omit these subtrees
@@ -686,20 +686,20 @@ of using this particular feature for accessibility detection.</p>
 with any personally identifiable or sensitive information. Hence, the risk to
 the user is low.</p>
    <p>It may seem that a cross-origin iframe can learn that it is offscreen, and
-under a subtree-visibility hidden or auto ancestor, by noticing that
+under a content-visibility hidden or auto ancestor, by noticing that
 requestAnimationFrame callbacks are not run. However, since user-agents are
 already <a href="https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity">allowed
 to throttle</a> or stop generating frames for off-screen cross-origin iframes
 and since <a data-link-type="dfn" href="#skipped" id="ref-for-skipped③③">skipped</a> element’s descendants are not intersecting the viewport
 from an IntersectionObserver perspective, the fact that
 requestionAnimationFrame callbacks are not run is insufficient information to
-detect <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑤">subtree-visibility</a> ancestors.</p>
+detect <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility②⑤">content-visibility</a> ancestors.</p>
    <h2 class="heading settled" data-level="7" id="examples"><span class="secno">7. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
-   <div class="example" id="example-6b713aeb">
-    <a class="self-link" href="#example-6b713aeb"></a> 
+   <div class="example" id="example-8b61ade0">
+    <a class="self-link" href="#example-8b61ade0"></a> 
 <pre class="highlight"><c- p>&lt;</c-><c- f>style</c-><c- p>></c->
 <c- p>.</c-><c- nc>sv</c-> <c- p>{</c->
-  <c- n>subtree-visibility</c-><c- p>:</c-> <c- kc>auto</c-><c- p>;</c->
+  <c- n>content-visibility</c-><c- p>:</c-> <c- kc>auto</c-><c- p>;</c->
   <c- k>min-height</c-><c- p>:</c-> <c- mi>50</c-><c- b>px</c-><c- p>;</c->
 <c- p>}</c->
 <c- p>&lt;/</c-><c- f>style</c-><c- p>></c->
@@ -708,18 +708,18 @@ detect <a class="property" data-link-type="propdesc" href="#propdef-subtree-visi
   ... some content goes here ...
 <c- p>&lt;/</c-><c- f>div</c-><c- p>></c->
 </pre>
-    <p>The .sv element’s <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑥">subtree-visibility</a> value <a data-link-type="dfn" href="#subtree-visibility-auto" id="ref-for-subtree-visibility-auto①">auto</a> lets the user-agent
+    <p>The .sv element’s <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility②⑥">content-visibility</a> value <a data-link-type="dfn" href="#content-visibility-auto" id="ref-for-content-visibility-auto①">auto</a> lets the user-agent
   manage whether the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped③④">skipped</a>.  Specifically when this element is
   near the viewport, the user-agent will begin painting the element.  When the
   element moves away from the viewport, it will stop being painted. In
   addition, the user-agent should skip as much of the rendering work as
   possible when the element is <span id="ref-for-skipped③⑤">skipped</span>.</p>
    </div>
-   <div class="example" id="example-d9055d5b">
-    <a class="self-link" href="#example-d9055d5b"></a> 
+   <div class="example" id="example-45a10f92">
+    <a class="self-link" href="#example-45a10f92"></a> 
 <pre class="highlight"><c- p>&lt;</c-><c- f>style</c-><c- p>></c->
 <c- p>.</c-><c- nc>sv</c-> <c- p>{</c->
-  <c- n>subtree-visibility</c-><c- p>:</c-> <c- kc>hidden</c-><c- p>;</c->
+  <c- n>content-visibility</c-><c- p>:</c-> <c- kc>hidden</c-><c- p>;</c->
 <c- p>}</c->
 <c- p>&lt;/</c-><c- f>style</c-><c- p>></c->
 
@@ -729,20 +729,20 @@ detect <a class="property" data-link-type="propdesc" href="#propdef-subtree-visi
 </pre>
     <p>In this case, the element is <a data-link-type="dfn" href="#skipped" id="ref-for-skipped③⑥">skipped</a> regardless of viewport intersection.
   This means that the only way to have this <a data-link-type="dfn" href="#subtree" id="ref-for-subtree①⑨">subtree</a> painted is via script
-  updating the value to remove <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑦">subtree-visibility</a> or change its value. As
+  updating the value to remove <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility②⑦">content-visibility</a> or change its value. As
   before, the user-agent should skip as much of the rendering in the <span id="ref-for-subtree②⓪">subtree</span> as
   possible.</p>
-    <p>An additional effect of skipping rendering is that the layout state of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②①">subtree</a> can be preserved by the user-agent, so that removing the <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑧">subtree-visibility</a> property in the future will cause the <span id="ref-for-subtree②②">subtree</span> to be
+    <p>An additional effect of skipping rendering is that the layout state of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②①">subtree</a> can be preserved by the user-agent, so that removing the <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility②⑧">content-visibility</a> property in the future will cause the <span id="ref-for-subtree②②">subtree</span> to be
   rendered quicker than otherwise possible.</p>
    </div>
-   <div class="example" id="example-536d29cb">
-    <a class="self-link" href="#example-536d29cb"></a> 
+   <div class="example" id="example-70e8b13c">
+    <a class="self-link" href="#example-70e8b13c"></a> 
 <pre class="highlight"><c- p>&lt;</c-><c- f>style</c-><c- p>></c->
 <c- f>body</c-> <c- p>{</c->
   <c- k>margin</c-><c- p>:</c-> <c- mi>0</c-><c- p>;</c->
 <c- p>}</c->
 <c- p>.</c-><c- nc>sv</c-> <c- p>{</c->
-  <c- n>subtree-visibility</c-><c- p>:</c-> <c- kc>hidden</c-><c- p>;</c->
+  <c- n>content-visibility</c-><c- p>:</c-> <c- kc>hidden</c-><c- p>;</c->
 
   <c- k>position</c-><c- p>:</c-> <c- kc>relative</c-><c- p>;</c->
   <c- k>left</c-><c- p>:</c-> <c- mi>10</c-><c- b>px</c-><c- p>;</c->
@@ -785,25 +785,25 @@ detect <a class="property" data-link-type="propdesc" href="#propdef-subtree-visi
   rendering work.</p>
    </div>
    <h2 class="heading settled" data-level="8" id="similarity"><span class="secno">8. </span><span class="content">Similarity to visibility</span><a class="self-link" href="#similarity"></a></h2>
-   <p>Note that <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility②⑨">subtree-visibility</a> bears some similarity in naming to <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility">visibility</a> which is important to address. Like <span class="property" id="ref-for-propdef-visibility①">visibility</span>, <span class="property" id="ref-for-propdef-subtree-visibility③⓪">subtree-visibility</span> controls
+   <p>Note that <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility②⑨">content-visibility</a> bears some similarity in naming to <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility">visibility</a> which is important to address. Like <span class="property" id="ref-for-propdef-visibility①">visibility</span>, <span class="property" id="ref-for-propdef-content-visibility③⓪">content-visibility</span> controls
 whether the element, or its <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②④">subtree</a>, are painted and hit-tested. However, it
 has important distinctions that allow both adoption in a wider set of use-cases
 and ability for user-agents to optimize rendering performance:</p>
    <ul>
     <li data-md>
-     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③①">subtree-visibility</a> values cannot be reverted by descendant style. As an
-example, when processing an element that has <span class="property" id="ref-for-propdef-subtree-visibility③②">subtree-visibility</span> value <a data-link-type="dfn" href="#subtree-visibility-hidden" id="ref-for-subtree-visibility-hidden①">hidden</a>, the user-agent will not paint any of its subtree, even if one of
-the elements in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑤">subtree</a> has <span class="property" id="ref-for-propdef-subtree-visibility③③">subtree-visibility</span> value <a data-link-type="dfn" href="#subtree-visibility-visible" id="ref-for-subtree-visibility-visible①">visible</a>. This
+     <p><a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility③①">content-visibility</a> values cannot be reverted by descendant style. As an
+example, when processing an element that has <span class="property" id="ref-for-propdef-content-visibility③②">content-visibility</span> value <a data-link-type="dfn" href="#content-visibility-hidden" id="ref-for-content-visibility-hidden①">hidden</a>, the user-agent will not paint any of its subtree, even if one of
+the elements in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑤">subtree</a> has <span class="property" id="ref-for-propdef-content-visibility③③">content-visibility</span> value <a data-link-type="dfn" href="#content-visibility-visible" id="ref-for-content-visibility-visible①">visible</a>. This
 is important as it makes it possible to skip style part of rendering in
-these <span id="ref-for-subtree②⑥">subtree</span>, since no descendant value can override <span class="property" id="ref-for-propdef-subtree-visibility③④">subtree-visibility</span>.</p>
+these <span id="ref-for-subtree②⑥">subtree</span>, since no descendant value can override <span class="property" id="ref-for-propdef-content-visibility③④">content-visibility</span>.</p>
     <li data-md>
-     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③⑤">subtree-visibility</a> has an <a data-link-type="dfn" href="#subtree-visibility-auto" id="ref-for-subtree-visibility-auto②">auto</a> value, which allows the user-agent to
+     <p><a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility③⑤">content-visibility</a> has an <a data-link-type="dfn" href="#content-visibility-auto" id="ref-for-content-visibility-auto②">auto</a> value, which allows the user-agent to
 paint the element’s <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑦">subtree</a> when it approaches the viewport. This allows easy
 adoption of the feature. In contrast, if <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility②">visibility</a> or <a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display">display: none</a> are
 used instead, then it is up to the developer to toggle the values when they
 approach the viewport.</p>
     <li data-md>
-     <p><a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③⑥">subtree-visibility</a> adds in containment. This is an important part of the
+     <p><a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility③⑥">content-visibility</a> adds in containment. This is an important part of the
 property, which allows the user-agent to skip rendering work in the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree②⑧">subtree</a>,
 since it can reason that when the element’s <span id="ref-for-subtree②⑨">subtree</span> is not painted, then the
 style and layout effects of the <span id="ref-for-subtree③⓪">subtree</span> will not affect any visible content.</p>
@@ -815,10 +815,10 @@ to render. Additionally, the cost of hiding and showing content cannot be
 eliminated since <span class="css" id="ref-for-propdef-display②">display: none</span> does not preserve the layout state of the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree③①">subtree</a>.</p>
    <p><a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility③">visibility: hidden</a> causes subtrees to not paint, but they still need style
 and layout, as the <a data-link-type="dfn" href="#subtree" id="ref-for-subtree③②">subtree</a> takes up layout space and descendants may be <span class="css" id="ref-for-propdef-visibility④">visibility: visible</span>. Note that with sufficient containment and intersection
-observer, the functionality provided by <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility③⑦">subtree-visibility</a> may be mimicked.
-However, <span class="css" id="ref-for-propdef-subtree-visibility③⑧">subtree-visibility: auto</span> also permits user-agent algorithms such
+observer, the functionality provided by <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility③⑦">content-visibility</a> may be mimicked.
+However, <span class="css" id="ref-for-propdef-content-visibility③⑧">content-visibility: auto</span> also permits user-agent algorithms such
 as find-in-page and fragment navigation to access the element’s <span id="ref-for-subtree③③">subtree</span>, which
-cannot be mimicked by <span class="css">visibility</span>. Overall, <span class="property" id="ref-for-propdef-subtree-visibility③⑨">subtree-visibility</span> property is
+cannot be mimicked by <span class="css">visibility</span>. Overall, <span class="property" id="ref-for-propdef-content-visibility③⑨">content-visibility</span> property is
 a stronger signal allowing the user-agent to optimize rendering.</p>
    <p>Similar to <a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility⑤">visibility: hidden</a>, <a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css-contain-2/#propdef-contain" id="ref-for-propdef-contain①">contain: strict</a> allows the browser to
 automatically detect subtrees that are definitely off-screen, and therefore
@@ -826,7 +826,7 @@ that don’t need to be rendered. However, <span class="css" id="ref-for-propdef
 flexible enough to allow for responsive design layouts that grow elements to
 fit their content. To work around this, content could be marked as ''contain:
 strict'' when off-screen and then some other value when on-screen (this is
-similar to <a class="property" data-link-type="propdesc" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility④⓪">subtree-visibility</a>). Second, <span class="css" id="ref-for-propdef-contain③">contain: strict</span> may or may not
+similar to <a class="property" data-link-type="propdesc" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility④⓪">content-visibility</a>). Second, <span class="css" id="ref-for-propdef-contain③">contain: strict</span> may or may not
 result in rendering work, depending on whether the browser detects the content
 is actually off-screen. Third, it does not support user-agent features in
 cases when it is not actually rendered to the user in the current application
@@ -941,15 +941,15 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#subtree-visibility-auto">auto</a><span>, in §3</span>
+   <li><a href="#content-visibility-auto">auto</a><span>, in §3</span>
+   <li><a href="#propdef-content-visibility">content-visibility</a><span>, in §3</span>
    <li><a href="#gains-containment">gains containment</a><span>, in §2</span>
-   <li><a href="#subtree-visibility-hidden">hidden</a><span>, in §3</span>
+   <li><a href="#content-visibility-hidden">hidden</a><span>, in §3</span>
    <li><a href="#off-screen">off-screen</a><span>, in §2</span>
    <li><a href="#on-screen">on-screen</a><span>, in §2</span>
    <li><a href="#skipped">skipped</a><span>, in §2</span>
    <li><a href="#subtree">subtree</a><span>, in §2</span>
-   <li><a href="#propdef-subtree-visibility">subtree-visibility</a><span>, in §3</span>
-   <li><a href="#subtree-visibility-visible">visible</a><span>, in §3</span>
+   <li><a href="#content-visibility-visible">visible</a><span>, in §3</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-propdef-margin-left">
    <a href="https://drafts.csswg.org/css-box-3/#propdef-margin-left">https://drafts.csswg.org/css-box-3/#propdef-margin-left</a><b>Referenced in:</b>
@@ -968,7 +968,7 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
    <a href="https://drafts.csswg.org/css-contain-2/#layout-containment">https://drafts.csswg.org/css-contain-2/#layout-containment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-containment">2. Definitions</a> <a href="#ref-for-layout-containment①">(2)</a>
-    <li><a href="#ref-for-layout-containment②">3. The subtree-visibility property</a> <a href="#ref-for-layout-containment③">(2)</a> <a href="#ref-for-layout-containment④">(3)</a>
+    <li><a href="#ref-for-layout-containment②">3. The content-visibility property</a> <a href="#ref-for-layout-containment③">(2)</a> <a href="#ref-for-layout-containment④">(3)</a>
     <li><a href="#ref-for-layout-containment⑤">4. Restrictions and Clarifications</a>
    </ul>
   </aside>
@@ -976,14 +976,14 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
    <a href="https://drafts.csswg.org/css-contain-2/#paint-containment">https://drafts.csswg.org/css-contain-2/#paint-containment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-containment">2. Definitions</a> <a href="#ref-for-paint-containment①">(2)</a>
-    <li><a href="#ref-for-paint-containment②">3. The subtree-visibility property</a> <a href="#ref-for-paint-containment③">(2)</a> <a href="#ref-for-paint-containment④">(3)</a>
+    <li><a href="#ref-for-paint-containment②">3. The content-visibility property</a> <a href="#ref-for-paint-containment③">(2)</a> <a href="#ref-for-paint-containment④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-size-containment">
    <a href="https://drafts.csswg.org/css-contain-2/#size-containment">https://drafts.csswg.org/css-contain-2/#size-containment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-size-containment">2. Definitions</a>
-    <li><a href="#ref-for-size-containment①">3. The subtree-visibility property</a> <a href="#ref-for-size-containment②">(2)</a>
+    <li><a href="#ref-for-size-containment①">3. The content-visibility property</a> <a href="#ref-for-size-containment②">(2)</a>
     <li><a href="#ref-for-size-containment③">4. Restrictions and Clarifications</a> <a href="#ref-for-size-containment④">(2)</a> <a href="#ref-for-size-containment⑤">(3)</a> <a href="#ref-for-size-containment⑥">(4)</a> <a href="#ref-for-size-containment⑦">(5)</a>
    </ul>
   </aside>
@@ -991,7 +991,7 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
    <a href="https://drafts.csswg.org/css-contain-2/#style-containment">https://drafts.csswg.org/css-contain-2/#style-containment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-containment">2. Definitions</a> <a href="#ref-for-style-containment①">(2)</a>
-    <li><a href="#ref-for-style-containment②">3. The subtree-visibility property</a> <a href="#ref-for-style-containment③">(2)</a> <a href="#ref-for-style-containment④">(3)</a>
+    <li><a href="#ref-for-style-containment②">3. The content-visibility property</a> <a href="#ref-for-style-containment③">(2)</a> <a href="#ref-for-style-containment④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-propdef-display">
@@ -1004,7 +1004,7 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
   <aside class="dfn-panel" data-for="term-for-ink-overflow">
    <a href="https://drafts.csswg.org/css-overflow-3/#ink-overflow">https://drafts.csswg.org/css-overflow-3/#ink-overflow</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-ink-overflow">3. The subtree-visibility property</a>
+    <li><a href="#ref-for-ink-overflow">3. The content-visibility property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-flat-tree">
@@ -1022,7 +1022,7 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
   <aside class="dfn-panel" data-for="term-for-comb-one">
    <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-comb-one">3. The subtree-visibility property</a> <a href="#ref-for-comb-one①">(2)</a>
+    <li><a href="#ref-for-comb-one">3. The content-visibility property</a> <a href="#ref-for-comb-one①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-propdef-will-change">
@@ -1127,7 +1127,7 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
       <th scope="col">Com­puted value
     <tbody>
      <tr>
-      <th scope="row"><a class="css" data-link-type="property" href="#propdef-subtree-visibility" id="ref-for-propdef-subtree-visibility④①">subtree-visibility</a>
+      <th scope="row"><a class="css" data-link-type="property" href="#propdef-content-visibility" id="ref-for-propdef-content-visibility④①">content-visibility</a>
       <td>visible | auto | hidden
       <td>visible
       <td>all elements
@@ -1143,7 +1143,7 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
    <ul>
     <li><a href="#ref-for-subtree">1.1. Motivation &amp; Background</a> <a href="#ref-for-subtree①">(2)</a> <a href="#ref-for-subtree②">(3)</a>
     <li><a href="#ref-for-subtree③">2. Definitions</a> <a href="#ref-for-subtree④">(2)</a> <a href="#ref-for-subtree⑤">(3)</a>
-    <li><a href="#ref-for-subtree⑥">3. The subtree-visibility property</a> <a href="#ref-for-subtree⑦">(2)</a> <a href="#ref-for-subtree⑧">(3)</a> <a href="#ref-for-subtree⑨">(4)</a> <a href="#ref-for-subtree①⓪">(5)</a> <a href="#ref-for-subtree①①">(6)</a> <a href="#ref-for-subtree①②">(7)</a> <a href="#ref-for-subtree①③">(8)</a> <a href="#ref-for-subtree①④">(9)</a>
+    <li><a href="#ref-for-subtree⑥">3. The content-visibility property</a> <a href="#ref-for-subtree⑦">(2)</a> <a href="#ref-for-subtree⑧">(3)</a> <a href="#ref-for-subtree⑨">(4)</a> <a href="#ref-for-subtree①⓪">(5)</a> <a href="#ref-for-subtree①①">(6)</a> <a href="#ref-for-subtree①②">(7)</a> <a href="#ref-for-subtree①③">(8)</a> <a href="#ref-for-subtree①④">(9)</a>
     <li><a href="#ref-for-subtree①⑤">4. Restrictions and Clarifications</a> <a href="#ref-for-subtree①⑥">(2)</a> <a href="#ref-for-subtree①⑦">(3)</a>
     <li><a href="#ref-for-subtree①⑧">5. Accessibility</a>
     <li><a href="#ref-for-subtree①⑨">7. Examples</a> <a href="#ref-for-subtree②⓪">(2)</a> <a href="#ref-for-subtree②①">(3)</a> <a href="#ref-for-subtree②②">(4)</a> <a href="#ref-for-subtree②③">(5)</a>
@@ -1155,14 +1155,14 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
    <b><a href="#off-screen">#off-screen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-off-screen">2. Definitions</a>
-    <li><a href="#ref-for-off-screen①">3. The subtree-visibility property</a> <a href="#ref-for-off-screen②">(2)</a>
+    <li><a href="#ref-for-off-screen①">3. The content-visibility property</a> <a href="#ref-for-off-screen②">(2)</a>
     <li><a href="#ref-for-off-screen③">4. Restrictions and Clarifications</a> <a href="#ref-for-off-screen④">(2)</a> <a href="#ref-for-off-screen⑤">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="skipped">
    <b><a href="#skipped">#skipped</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-skipped">3. The subtree-visibility property</a> <a href="#ref-for-skipped①">(2)</a> <a href="#ref-for-skipped②">(3)</a> <a href="#ref-for-skipped③">(4)</a> <a href="#ref-for-skipped④">(5)</a> <a href="#ref-for-skipped⑤">(6)</a> <a href="#ref-for-skipped⑥">(7)</a> <a href="#ref-for-skipped⑦">(8)</a> <a href="#ref-for-skipped⑧">(9)</a> <a href="#ref-for-skipped⑨">(10)</a> <a href="#ref-for-skipped①⓪">(11)</a> <a href="#ref-for-skipped①①">(12)</a> <a href="#ref-for-skipped①②">(13)</a> <a href="#ref-for-skipped①③">(14)</a> <a href="#ref-for-skipped①④">(15)</a>
+    <li><a href="#ref-for-skipped">3. The content-visibility property</a> <a href="#ref-for-skipped①">(2)</a> <a href="#ref-for-skipped②">(3)</a> <a href="#ref-for-skipped③">(4)</a> <a href="#ref-for-skipped④">(5)</a> <a href="#ref-for-skipped⑤">(6)</a> <a href="#ref-for-skipped⑥">(7)</a> <a href="#ref-for-skipped⑦">(8)</a> <a href="#ref-for-skipped⑧">(9)</a> <a href="#ref-for-skipped⑨">(10)</a> <a href="#ref-for-skipped①⓪">(11)</a> <a href="#ref-for-skipped①①">(12)</a> <a href="#ref-for-skipped①②">(13)</a> <a href="#ref-for-skipped①③">(14)</a> <a href="#ref-for-skipped①④">(15)</a>
     <li><a href="#ref-for-skipped①⑤">4. Restrictions and Clarifications</a> <a href="#ref-for-skipped①⑥">(2)</a> <a href="#ref-for-skipped①⑦">(3)</a> <a href="#ref-for-skipped①⑧">(4)</a> <a href="#ref-for-skipped①⑨">(5)</a> <a href="#ref-for-skipped②⓪">(6)</a> <a href="#ref-for-skipped②①">(7)</a> <a href="#ref-for-skipped②②">(8)</a> <a href="#ref-for-skipped②③">(9)</a> <a href="#ref-for-skipped②④">(10)</a> <a href="#ref-for-skipped②⑤">(11)</a> <a href="#ref-for-skipped②⑥">(12)</a> <a href="#ref-for-skipped②⑦">(13)</a> <a href="#ref-for-skipped②⑧">(14)</a>
     <li><a href="#ref-for-skipped②⑨">5. Accessibility</a> <a href="#ref-for-skipped③⓪">(2)</a> <a href="#ref-for-skipped③①">(3)</a> <a href="#ref-for-skipped③②">(4)</a>
     <li><a href="#ref-for-skipped③③">6. Privacy &amp; Security Considerations</a>
@@ -1172,42 +1172,42 @@ and avoiding some or most rendering lifecycle phases for such content. </p>
   <aside class="dfn-panel" data-for="gains-containment">
    <b><a href="#gains-containment">#gains-containment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-gains-containment">3. The subtree-visibility property</a>
+    <li><a href="#ref-for-gains-containment">3. The content-visibility property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-subtree-visibility">
-   <b><a href="#propdef-subtree-visibility">#propdef-subtree-visibility</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="propdef-content-visibility">
+   <b><a href="#propdef-content-visibility">#propdef-content-visibility</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-subtree-visibility">2. Definitions</a>
-    <li><a href="#ref-for-propdef-subtree-visibility①">3. The subtree-visibility property</a> <a href="#ref-for-propdef-subtree-visibility②">(2)</a> <a href="#ref-for-propdef-subtree-visibility③">(3)</a> <a href="#ref-for-propdef-subtree-visibility④">(4)</a> <a href="#ref-for-propdef-subtree-visibility⑤">(5)</a> <a href="#ref-for-propdef-subtree-visibility⑥">(6)</a> <a href="#ref-for-propdef-subtree-visibility⑦">(7)</a> <a href="#ref-for-propdef-subtree-visibility⑧">(8)</a> <a href="#ref-for-propdef-subtree-visibility⑨">(9)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility①⓪">4. Restrictions and Clarifications</a> <a href="#ref-for-propdef-subtree-visibility①①">(2)</a> <a href="#ref-for-propdef-subtree-visibility①②">(3)</a> <a href="#ref-for-propdef-subtree-visibility①③">(4)</a> <a href="#ref-for-propdef-subtree-visibility①④">(5)</a> <a href="#ref-for-propdef-subtree-visibility①⑤">(6)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility①⑥">5. Accessibility</a> <a href="#ref-for-propdef-subtree-visibility①⑦">(2)</a> <a href="#ref-for-propdef-subtree-visibility①⑧">(3)</a> <a href="#ref-for-propdef-subtree-visibility①⑨">(4)</a> <a href="#ref-for-propdef-subtree-visibility②⓪">(5)</a> <a href="#ref-for-propdef-subtree-visibility②①">(6)</a> <a href="#ref-for-propdef-subtree-visibility②②">(7)</a> <a href="#ref-for-propdef-subtree-visibility②③">(8)</a> <a href="#ref-for-propdef-subtree-visibility②④">(9)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility②⑤">6. Privacy &amp; Security Considerations</a>
-    <li><a href="#ref-for-propdef-subtree-visibility②⑥">7. Examples</a> <a href="#ref-for-propdef-subtree-visibility②⑦">(2)</a> <a href="#ref-for-propdef-subtree-visibility②⑧">(3)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility②⑨">8. Similarity to visibility</a> <a href="#ref-for-propdef-subtree-visibility③⓪">(2)</a> <a href="#ref-for-propdef-subtree-visibility③①">(3)</a> <a href="#ref-for-propdef-subtree-visibility③②">(4)</a> <a href="#ref-for-propdef-subtree-visibility③③">(5)</a> <a href="#ref-for-propdef-subtree-visibility③④">(6)</a> <a href="#ref-for-propdef-subtree-visibility③⑤">(7)</a> <a href="#ref-for-propdef-subtree-visibility③⑥">(8)</a>
-    <li><a href="#ref-for-propdef-subtree-visibility③⑦">9. Alternatives Considered</a> <a href="#ref-for-propdef-subtree-visibility③⑧">(2)</a> <a href="#ref-for-propdef-subtree-visibility③⑨">(3)</a> <a href="#ref-for-propdef-subtree-visibility④⓪">(4)</a>
+    <li><a href="#ref-for-propdef-content-visibility">2. Definitions</a>
+    <li><a href="#ref-for-propdef-content-visibility①">3. The content-visibility property</a> <a href="#ref-for-propdef-content-visibility②">(2)</a> <a href="#ref-for-propdef-content-visibility③">(3)</a> <a href="#ref-for-propdef-content-visibility④">(4)</a> <a href="#ref-for-propdef-content-visibility⑤">(5)</a> <a href="#ref-for-propdef-content-visibility⑥">(6)</a> <a href="#ref-for-propdef-content-visibility⑦">(7)</a> <a href="#ref-for-propdef-content-visibility⑧">(8)</a> <a href="#ref-for-propdef-content-visibility⑨">(9)</a>
+    <li><a href="#ref-for-propdef-content-visibility①⓪">4. Restrictions and Clarifications</a> <a href="#ref-for-propdef-content-visibility①①">(2)</a> <a href="#ref-for-propdef-content-visibility①②">(3)</a> <a href="#ref-for-propdef-content-visibility①③">(4)</a> <a href="#ref-for-propdef-content-visibility①④">(5)</a> <a href="#ref-for-propdef-content-visibility①⑤">(6)</a>
+    <li><a href="#ref-for-propdef-content-visibility①⑥">5. Accessibility</a> <a href="#ref-for-propdef-content-visibility①⑦">(2)</a> <a href="#ref-for-propdef-content-visibility①⑧">(3)</a> <a href="#ref-for-propdef-content-visibility①⑨">(4)</a> <a href="#ref-for-propdef-content-visibility②⓪">(5)</a> <a href="#ref-for-propdef-content-visibility②①">(6)</a> <a href="#ref-for-propdef-content-visibility②②">(7)</a> <a href="#ref-for-propdef-content-visibility②③">(8)</a> <a href="#ref-for-propdef-content-visibility②④">(9)</a>
+    <li><a href="#ref-for-propdef-content-visibility②⑤">6. Privacy &amp; Security Considerations</a>
+    <li><a href="#ref-for-propdef-content-visibility②⑥">7. Examples</a> <a href="#ref-for-propdef-content-visibility②⑦">(2)</a> <a href="#ref-for-propdef-content-visibility②⑧">(3)</a>
+    <li><a href="#ref-for-propdef-content-visibility②⑨">8. Similarity to visibility</a> <a href="#ref-for-propdef-content-visibility③⓪">(2)</a> <a href="#ref-for-propdef-content-visibility③①">(3)</a> <a href="#ref-for-propdef-content-visibility③②">(4)</a> <a href="#ref-for-propdef-content-visibility③③">(5)</a> <a href="#ref-for-propdef-content-visibility③④">(6)</a> <a href="#ref-for-propdef-content-visibility③⑤">(7)</a> <a href="#ref-for-propdef-content-visibility③⑥">(8)</a>
+    <li><a href="#ref-for-propdef-content-visibility③⑦">9. Alternatives Considered</a> <a href="#ref-for-propdef-content-visibility③⑧">(2)</a> <a href="#ref-for-propdef-content-visibility③⑨">(3)</a> <a href="#ref-for-propdef-content-visibility④⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="subtree-visibility-visible">
-   <b><a href="#subtree-visibility-visible">#subtree-visibility-visible</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="content-visibility-visible">
+   <b><a href="#content-visibility-visible">#content-visibility-visible</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-subtree-visibility-visible">3. The subtree-visibility property</a>
-    <li><a href="#ref-for-subtree-visibility-visible①">8. Similarity to visibility</a>
+    <li><a href="#ref-for-content-visibility-visible">3. The content-visibility property</a>
+    <li><a href="#ref-for-content-visibility-visible①">8. Similarity to visibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="subtree-visibility-auto">
-   <b><a href="#subtree-visibility-auto">#subtree-visibility-auto</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="content-visibility-auto">
+   <b><a href="#content-visibility-auto">#content-visibility-auto</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-subtree-visibility-auto">3. The subtree-visibility property</a>
-    <li><a href="#ref-for-subtree-visibility-auto①">7. Examples</a>
-    <li><a href="#ref-for-subtree-visibility-auto②">8. Similarity to visibility</a>
+    <li><a href="#ref-for-content-visibility-auto">3. The content-visibility property</a>
+    <li><a href="#ref-for-content-visibility-auto①">7. Examples</a>
+    <li><a href="#ref-for-content-visibility-auto②">8. Similarity to visibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="subtree-visibility-hidden">
-   <b><a href="#subtree-visibility-hidden">#subtree-visibility-hidden</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="content-visibility-hidden">
+   <b><a href="#content-visibility-hidden">#content-visibility-hidden</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-subtree-visibility-hidden">3. The subtree-visibility property</a>
-    <li><a href="#ref-for-subtree-visibility-hidden①">8. Similarity to visibility</a>
+    <li><a href="#ref-for-content-visibility-hidden">3. The content-visibility property</a>
+    <li><a href="#ref-for-content-visibility-hidden①">8. Similarity to visibility</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
This renames the feature from subtree-visibility to content-visibility. The term subtree is still used and defined here, which I think is useful, since just talking about content may be ambiguous. 